### PR TITLE
Make default entitlements accessible outside the lib

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -3,8 +3,8 @@ package defaults
 import "github.com/docker/libentitlement/entitlement"
 
 var DefaultEntitlements = map[string]entitlement.Entitlement{
-	NetworkNoneEntFullId:  &entitlement.Entitlement(networkNoneEntitlement),
-	NetworkUserEntFullId:  &entitlement.Entitlement(networkUserEntitlement),
-	NetworkProxyEntFullId: &entitlement.Entitlement(networkProxyEntitlement),
-	NetworkAdminEntFullId: &entitlement.Entitlement(networkAdminEntitlement),
+	NetworkNoneEntFullId:  entitlement.Entitlement(networkNoneEntitlement),
+	NetworkUserEntFullId:  entitlement.Entitlement(networkUserEntitlement),
+	NetworkProxyEntFullId: entitlement.Entitlement(networkProxyEntitlement),
+	NetworkAdminEntFullId: entitlement.Entitlement(networkAdminEntitlement),
 }

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -1,0 +1,10 @@
+package defaults
+
+import "github.com/docker/libentitlement/entitlement"
+
+var DefaultEntitlements = map[string]entitlement.Entitlement{
+	NetworkNoneEntFullId:  &entitlement.Entitlement(networkNoneEntitlement),
+	NetworkUserEntFullId:  &entitlement.Entitlement(networkUserEntitlement),
+	NetworkProxyEntFullId: &entitlement.Entitlement(networkProxyEntitlement),
+	NetworkAdminEntFullId: &entitlement.Entitlement(networkAdminEntitlement),
+}

--- a/defaults/network-ents.go
+++ b/defaults/network-ents.go
@@ -4,7 +4,6 @@ import (
 	"github.com/docker/libentitlement/entitlement"
 	secProfile "github.com/docker/libentitlement/security-profile"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"strings"
 	"syscall"
 )
 

--- a/defaults/network-ents.go
+++ b/defaults/network-ents.go
@@ -1,8 +1,10 @@
 package defaults
 
 import (
+	"github.com/docker/libentitlement/entitlement"
 	secProfile "github.com/docker/libentitlement/security-profile"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"strings"
 	"syscall"
 )
 
@@ -11,10 +13,17 @@ const (
 )
 
 const (
-	NetworkNoneEntId  = "none"  // network.none
-	NetworkUserEntId  = "user"  // network.user
-	NetworkProxyEntId = "proxy" // network.proxy
-	NetworkAdminEntId = "admin" // network.admin
+	NetworkNoneEntFullId  = NetworkTLD + ".none"
+	NetworkUserEntFullId  = NetworkTLD + ".user"
+	NetworkProxyEntFullId = NetworkTLD + ".proxy"
+	NetworkAdminEntFullId = NetworkTLD + ".admin"
+)
+
+var (
+	networkNoneEntitlement  = entitlement.NewVoidEntitlement(NetworkNoneEntFullId, networkNoneEntitlementEnforce)
+	networkUserEntitlement  = entitlement.NewVoidEntitlement(NetworkUserEntFullId, networkUserEntitlementEnforce)
+	networkProxyEntitlement = entitlement.NewVoidEntitlement(NetworkNoneEntFullId, networkProxyEntitlementEnforce)
+	networkAdminEntitlement = entitlement.NewVoidEntitlement(NetworkNoneEntFullId, networkAdminEntitlementEnforce)
 )
 
 /* Implements "network.none" entitlement
@@ -26,7 +35,7 @@ const (
  *     setdomainname, bpf
  * - Add network namespace
  */
-func NetworkNoneEntitlement(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkNoneEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
 	capsToRemove := []string{"CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE", "CAP_NET_RAW", "CAP_NET_BROADCAST"}
 	profile.RemoveCaps(capsToRemove...)
 
@@ -53,7 +62,7 @@ func NetworkNoneEntitlement(profile *secProfile.Profile) (*secProfile.Profile, e
  * - Blocked syscalls:
  * 	sethostname, setdomainname bpf, setsockopt(SO_DEBUG)
  */
-func NetworkUserEntitlement(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkUserEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
 	capsToRemove := []string{"CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE", "CAP_NET_RAW"}
 	profile.RemoveCaps(capsToRemove...)
 
@@ -80,7 +89,7 @@ func NetworkUserEntitlement(profile *secProfile.Profile) (*secProfile.Profile, e
 	return profile, nil
 }
 
-func NetworkProxyEntitlement(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkProxyEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
 	capsToRemove := []string{"CAP_NET_ADMIN"}
 	profile.RemoveCaps(capsToRemove...)
 
@@ -102,7 +111,7 @@ func NetworkProxyEntitlement(profile *secProfile.Profile) (*secProfile.Profile, 
 	return profile, nil
 }
 
-func NetworkAdminEntitlement(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkAdminEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
 	capsToAdd := []string{"CAP_NET_BROADCAST", "CAP_NET_RAW", "CAP_NET_BIND_SERVICE", "CAP_NET_ADMIN"}
 	profile.AddCaps(capsToAdd...)
 

--- a/libentitlement.go
+++ b/libentitlement.go
@@ -3,6 +3,7 @@ package libentitlement
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/libentitlement/defaults"
 	"github.com/docker/libentitlement/domain"
 	"github.com/docker/libentitlement/entitlement"
 	secprofile "github.com/docker/libentitlement/security-profile"
@@ -19,7 +20,7 @@ type EntitlementsManager struct {
 // default
 func NewEntitlementsManager(profile *secprofile.Profile) *EntitlementsManager {
 	if profile == nil {
-		logrus.Errorf("EntilementsManager initialization: invalid security profile - cannot be nil")
+		logrus.Errorf("Entilements Manager initialization: invalid security profile - cannot be nil")
 		return nil
 	}
 
@@ -31,8 +32,22 @@ func NewEntitlementsManager(profile *secprofile.Profile) *EntitlementsManager {
 }
 
 // GetProfile() returns the current state of the security profile
-func (m *EntitlementsManager) GetProfile() *secprofile.Profile {
-	return m.profile
+func (m *EntitlementsManager) GetProfile() (*secprofile.Profile, error) {
+	if m.profile == nil {
+		return nil, fmt.Errorf("Entitlements Manager has np security profile.")
+	}
+
+	return m.profile, nil
+}
+
+// SetProfile() sets the entitlement manager's security profile
+func (m *EntitlementsManager) SetProfile(profile *secprofile.Profile) error {
+	if profile == nil {
+		return fmt.Errorf("Invalid security profile")
+	}
+
+	m.profile = profile
+	return nil
 }
 
 func isValidEntitlement(ent entitlement.Entitlement) (bool, error) {
@@ -52,6 +67,16 @@ func isValidEntitlement(ent entitlement.Entitlement) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// AddDefault() adds a default entitlement identified by the "
+func (m *EntitlementsManager) AddDefault(entName string) error {
+	defaultEnt, ok := defaults.DefaultEntitlements[entName]
+	if !ok {
+		return fmt.Errorf("Couldn't add invalid default entitlement name")
+	}
+
+	return m.Add(defaultEnt)
 }
 
 // Add() adds the given entitlements to the current entitlements list, updates the domain name system and enforce

--- a/libentitlement.go
+++ b/libentitlement.go
@@ -178,7 +178,12 @@ func (m *EntitlementsManager) Enforce() error {
 		}
 
 		// Try to enforce the entitlement on the security profile
-		newProfile, err := ent.Enforce(m.GetProfile())
+		profile, err := m.GetProfile()
+		if err != nil {
+			return err
+		}
+
+		newProfile, err := ent.Enforce(profile)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
We create a map of the default entitlements and an `AddDefault` in the lib interface to add and enforce default entitlements.

Signed-off-by: Nassim 'Nass' Eddequiouaq <eddequiouaq.nassim@gmail.com>