### PR TITLE
Improve interface and fix issues - POC working end-to-end with Docker

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -3,8 +3,8 @@ package defaults
 import "github.com/docker/libentitlement/entitlement"
 
 var DefaultEntitlements = map[string]entitlement.Entitlement{
-	NetworkNoneEntFullId:  &entitlement.Entitlement(networkNoneEntitlement),
-	NetworkUserEntFullId:  &entitlement.Entitlement(networkUserEntitlement),
-	NetworkProxyEntFullId: &entitlement.Entitlement(networkProxyEntitlement),
-	NetworkAdminEntFullId: &entitlement.Entitlement(networkAdminEntitlement),
+	NetworkNoneEntFullId:  entitlement.Entitlement(networkNoneEntitlement),
+	NetworkUserEntFullId:  entitlement.Entitlement(networkUserEntitlement),
+	NetworkProxyEntFullId: entitlement.Entitlement(networkProxyEntitlement),
+	NetworkAdminEntFullId: entitlement.Entitlement(networkAdminEntitlement),
 }

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -1,0 +1,10 @@
+package defaults
+
+import "github.com/docker/libentitlement/entitlement"
+
+var DefaultEntitlements = map[string]entitlement.Entitlement{
+	NetworkNoneEntFullId:  &entitlement.Entitlement(networkNoneEntitlement),
+	NetworkUserEntFullId:  &entitlement.Entitlement(networkUserEntitlement),
+	NetworkProxyEntFullId: &entitlement.Entitlement(networkProxyEntitlement),
+	NetworkAdminEntFullId: &entitlement.Entitlement(networkAdminEntitlement),
+}

--- a/defaults/network-ents.go
+++ b/defaults/network-ents.go
@@ -69,7 +69,7 @@ func networkUserEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Pro
 	profile.AddCaps(capsToAdd...)
 
 	syscallsToBlock := []string{
-		"sethostname", "setdomainname", "bpf",
+		"sethostname", "setdomainname",
 	}
 	profile.BlockSyscalls(syscallsToBlock...)
 

--- a/defaults/network-ents.go
+++ b/defaults/network-ents.go
@@ -4,7 +4,6 @@ import (
 	"github.com/docker/libentitlement/entitlement"
 	secProfile "github.com/docker/libentitlement/security-profile"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"strings"
 	"syscall"
 )
 

--- a/defaults/network-ents.go
+++ b/defaults/network-ents.go
@@ -50,6 +50,22 @@ func networkNoneEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Pro
 	}
 	profile.BlockSyscalls(syscallsToBlock...)
 
+	syscallsWithArgsToAllow := map[string][]specs.LinuxSeccompArg{
+		"socket": {
+			{
+				Index: 0,
+				Op: specs.OpEqualTo,
+				Value: syscall.AF_UNIX,
+			},
+			{
+				Index: 0,
+				Op: specs.OpEqualTo,
+				Value: syscall.AF_LOCAL,
+			},
+		},
+	}
+	profile.AllowSyscallsWithArgs(syscallsWithArgsToAllow)
+
 	// FIXME: build an Apparmor Profile if necessary + add `deny network`
 
 	return profile, nil

--- a/defaults/network-ents.go
+++ b/defaults/network-ents.go
@@ -85,7 +85,7 @@ func networkUserEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Pro
 	profile.AddCaps(capsToAdd...)
 
 	syscallsToBlock := []string{
-		"sethostname", "setdomainname",
+		"sethostname", "setdomainname", "setsockopt",
 	}
 	profile.BlockSyscalls(syscallsToBlock...)
 
@@ -94,12 +94,11 @@ func networkUserEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Pro
 			{
 				Index:    2,
 				Value:    syscall.SO_DEBUG,
-				ValueTwo: 0,
-				Op:       specs.OpEqualTo,
+				Op:       specs.OpNotEqual,
 			},
 		},
 	}
-	profile.BlockSyscallsWithArgs(syscallsWithArgsToBlock)
+	profile.AllowSyscallsWithArgs(syscallsWithArgsToBlock)
 
 	return profile, nil
 }

--- a/defaults/network-ents.go
+++ b/defaults/network-ents.go
@@ -54,12 +54,12 @@ func networkNoneEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Pro
 		"socket": {
 			{
 				Index: 0,
-				Op: specs.OpEqualTo,
+				Op:    specs.OpEqualTo,
 				Value: syscall.AF_UNIX,
 			},
 			{
 				Index: 0,
-				Op: specs.OpEqualTo,
+				Op:    specs.OpEqualTo,
 				Value: syscall.AF_LOCAL,
 			},
 		},
@@ -92,9 +92,9 @@ func networkUserEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Pro
 	syscallsWithArgsToBlock := map[string][]specs.LinuxSeccompArg{
 		"setsockopt": {
 			{
-				Index:    2,
-				Value:    syscall.SO_DEBUG,
-				Op:       specs.OpNotEqual,
+				Index: 2,
+				Value: syscall.SO_DEBUG,
+				Op:    specs.OpNotEqual,
 			},
 		},
 	}

--- a/defaults/network-ents.go
+++ b/defaults/network-ents.go
@@ -8,14 +8,14 @@ import (
 )
 
 const (
-	NetworkTLD = "network"
+	networkDomain = "network"
 )
 
 const (
-	NetworkNoneEntFullId  = NetworkTLD + ".none"
-	NetworkUserEntFullId  = NetworkTLD + ".user"
-	NetworkProxyEntFullId = NetworkTLD + ".proxy"
-	NetworkAdminEntFullId = NetworkTLD + ".admin"
+	NetworkNoneEntFullId  = networkDomain + ".none"
+	NetworkUserEntFullId  = networkDomain + ".user"
+	NetworkProxyEntFullId = networkDomain + ".proxy"
+	NetworkAdminEntFullId = networkDomain + ".admin"
 )
 
 var (
@@ -31,7 +31,7 @@ var (
  * - Blocked syscalls:
  *     socket, socketpair, setsockopt, getsockopt, getsockname, getpeername, bind, listen, accept,
  *     accept4, connect, shutdown,recvfrom, recvmsg, sendto, sendmsg, sendmmsg, sethostname,
- *     setdomainname, bpf
+ *     setdomainname
  * - Add network namespace
  */
 func networkNoneEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
@@ -46,7 +46,7 @@ func networkNoneEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Pro
 
 	syscallsToBlock := []string{"socket", "socketpair", "setsockopt", "getsockopt", "getsockname", "getpeername",
 		"bind", "listen", "accept", "accept4", "connect", "shutdown", "recvfrom", "recvmsg", "sendto",
-		"sendmsg", "sendmmsg", "sethostname",
+		"sendmsg", "sendmmsg", "sethostname", "setdomainname",
 	}
 	profile.BlockSyscalls(syscallsToBlock...)
 
@@ -75,7 +75,7 @@ func networkNoneEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Pro
  * - No caps: CAP_NET_ADMIN, CAP_NET_RAW, CAP_NET_BIND_SERVICE
  * - Authorized caps: CAP_NET_BROADCAST
  * - Blocked syscalls:
- * 	sethostname, setdomainname bpf, setsockopt(SO_DEBUG)
+ * 	sethostname, setdomainname, setsockopt(SO_DEBUG)
  */
 func networkUserEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
 	capsToRemove := []string{"CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE", "CAP_NET_RAW"}

--- a/defaults/network-ents.go
+++ b/defaults/network-ents.go
@@ -21,8 +21,8 @@ const (
 var (
 	networkNoneEntitlement  = entitlement.NewVoidEntitlement(NetworkNoneEntFullId, networkNoneEntitlementEnforce)
 	networkUserEntitlement  = entitlement.NewVoidEntitlement(NetworkUserEntFullId, networkUserEntitlementEnforce)
-	networkProxyEntitlement = entitlement.NewVoidEntitlement(NetworkNoneEntFullId, networkProxyEntitlementEnforce)
-	networkAdminEntitlement = entitlement.NewVoidEntitlement(NetworkNoneEntFullId, networkAdminEntitlementEnforce)
+	networkProxyEntitlement = entitlement.NewVoidEntitlement(NetworkProxyEntFullId, networkProxyEntitlementEnforce)
+	networkAdminEntitlement = entitlement.NewVoidEntitlement(NetworkAdminEntFullId, networkAdminEntitlementEnforce)
 )
 
 /* Implements "network.none" entitlement

--- a/defaults/network-ents.go
+++ b/defaults/network-ents.go
@@ -1,8 +1,10 @@
 package defaults
 
 import (
+	"github.com/docker/libentitlement/entitlement"
 	secProfile "github.com/docker/libentitlement/security-profile"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"strings"
 	"syscall"
 )
 
@@ -11,10 +13,17 @@ const (
 )
 
 const (
-	NetworkNoneEntId  = "none"  // network.none
-	NetworkUserEntId  = "user"  // network.user
-	NetworkProxyEntId = "proxy" // network.proxy
-	NetworkAdminEntId = "admin" // network.admin
+	NetworkNoneEntFullId  = NetworkTLD + ".none"
+	NetworkUserEntFullId  = NetworkTLD + ".user"
+	NetworkProxyEntFullId = NetworkTLD + ".proxy"
+	NetworkAdminEntFullId = NetworkTLD + ".admin"
+)
+
+var (
+	networkNoneEntitlement  = entitlement.NewVoidEntitlement(NetworkNoneEntFullId, networkNoneEntitlementEnforce)
+	networkUserEntitlement  = entitlement.NewVoidEntitlement(NetworkUserEntFullId, networkUserEntitlementEnforce)
+	networkProxyEntitlement = entitlement.NewVoidEntitlement(NetworkNoneEntFullId, networkProxyEntitlementEnforce)
+	networkAdminEntitlement = entitlement.NewVoidEntitlement(NetworkNoneEntFullId, networkAdminEntitlementEnforce)
 )
 
 /* Implements "network.none" entitlement
@@ -26,7 +35,7 @@ const (
  *     setdomainname, bpf
  * - Add network namespace
  */
-func NetworkNoneEntitlement(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkNoneEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
 	capsToRemove := []string{"CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE", "CAP_NET_RAW", "CAP_NET_BROADCAST"}
 	profile.RemoveCaps(capsToRemove...)
 
@@ -53,7 +62,7 @@ func NetworkNoneEntitlement(profile *secProfile.Profile) (*secProfile.Profile, e
  * - Blocked syscalls:
  * 	sethostname, setdomainname bpf, setsockopt(SO_DEBUG)
  */
-func NetworkUserEntitlement(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkUserEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
 	capsToRemove := []string{"CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE", "CAP_NET_RAW"}
 	profile.RemoveCaps(capsToRemove...)
 
@@ -80,7 +89,7 @@ func NetworkUserEntitlement(profile *secProfile.Profile) (*secProfile.Profile, e
 	return profile, nil
 }
 
-func NetworkProxyEntitlement(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkProxyEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
 	capsToRemove := []string{"CAP_NET_ADMIN"}
 	profile.RemoveCaps(capsToRemove...)
 
@@ -102,7 +111,7 @@ func NetworkProxyEntitlement(profile *secProfile.Profile) (*secProfile.Profile, 
 	return profile, nil
 }
 
-func NetworkAdminEntitlement(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkAdminEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
 	capsToAdd := []string{"CAP_NET_BROADCAST", "CAP_NET_RAW", "CAP_NET_BIND_SERVICE", "CAP_NET_ADMIN"}
 	profile.AddCaps(capsToAdd...)
 

--- a/libentitlement.go
+++ b/libentitlement.go
@@ -3,6 +3,7 @@ package libentitlement
 import (
 	"fmt"
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/libentitlement/defaults"
 	"github.com/docker/libentitlement/domain"
 	"github.com/docker/libentitlement/entitlement"
 	secprofile "github.com/docker/libentitlement/security-profile"
@@ -19,7 +20,7 @@ type EntitlementsManager struct {
 // default
 func NewEntitlementsManager(profile *secprofile.Profile) *EntitlementsManager {
 	if profile == nil {
-		logrus.Errorf("EntilementsManager initialization: invalid security profile - cannot be nil")
+		logrus.Errorf("Entilements Manager initialization: invalid security profile - cannot be nil")
 		return nil
 	}
 
@@ -31,8 +32,22 @@ func NewEntitlementsManager(profile *secprofile.Profile) *EntitlementsManager {
 }
 
 // GetProfile() returns the current state of the security profile
-func (m *EntitlementsManager) GetProfile() *secprofile.Profile {
-	return m.profile
+func (m *EntitlementsManager) GetProfile() (*secprofile.Profile, error) {
+	if m.profile == nil {
+		return nil, fmt.Errorf("Entitlements Manager has np security profile.")
+	}
+
+	return m.profile, nil
+}
+
+// SetProfile() sets the entitlement manager's security profile
+func (m *EntitlementsManager) SetProfile(profile *secprofile.Profile) error {
+	if profile == nil {
+		return fmt.Errorf("Invalid security profile")
+	}
+
+	m.profile = profile
+	return nil
 }
 
 func isValidEntitlement(ent entitlement.Entitlement) (bool, error) {
@@ -52,6 +67,16 @@ func isValidEntitlement(ent entitlement.Entitlement) (bool, error) {
 	}
 
 	return true, nil
+}
+
+// AddDefault() adds a default entitlement identified by the "
+func (m *EntitlementsManager) AddDefault(entName string) error {
+	defaultEnt, ok := defaults.DefaultEntitlements[entName]
+	if !ok {
+		return fmt.Errorf("Couldn't add invalid default entitlement name")
+	}
+
+	return m.Add(defaultEnt)
 }
 
 // Add() adds the given entitlements to the current entitlements list, updates the domain name system and enforce

--- a/libentitlement.go
+++ b/libentitlement.go
@@ -20,7 +20,7 @@ type EntitlementsManager struct {
 // default
 func NewEntitlementsManager(profile *secprofile.Profile) *EntitlementsManager {
 	if profile == nil {
-		logrus.Errorf("Entilement Manager initialization: invalid security profile - cannot be nil")
+		logrus.Errorf("Entilements Manager initialization: invalid security profile - cannot be nil")
 		return nil
 	}
 
@@ -34,7 +34,7 @@ func NewEntitlementsManager(profile *secprofile.Profile) *EntitlementsManager {
 // GetProfile() returns the current state of the security profile
 func (m *EntitlementsManager) GetProfile() (*secprofile.Profile, error) {
 	if m.profile == nil {
-		return nil, fmt.Errorf("Entitlement Manager doesn't have a security profile.")
+		return nil, fmt.Errorf("Entitlements Manager doesn't have a security profile.")
 	}
 
 	return m.profile, nil

--- a/libentitlement.go
+++ b/libentitlement.go
@@ -178,7 +178,12 @@ func (m *EntitlementsManager) Enforce() error {
 		}
 
 		// Try to enforce the entitlement on the security profile
-		newProfile, err := ent.Enforce(m.GetProfile())
+		profile, err := m.GetProfile()
+		if err != nil {
+			return err
+		}
+
+		newProfile, err := ent.Enforce(profile)
 		if err != nil {
 			return err
 		}

--- a/libentitlement.go
+++ b/libentitlement.go
@@ -20,7 +20,7 @@ type EntitlementsManager struct {
 // default
 func NewEntitlementsManager(profile *secprofile.Profile) *EntitlementsManager {
 	if profile == nil {
-		logrus.Errorf("Entilements Manager initialization: invalid security profile - cannot be nil")
+		logrus.Errorf("Entilement Manager initialization: invalid security profile - cannot be nil")
 		return nil
 	}
 
@@ -34,7 +34,7 @@ func NewEntitlementsManager(profile *secprofile.Profile) *EntitlementsManager {
 // GetProfile() returns the current state of the security profile
 func (m *EntitlementsManager) GetProfile() (*secprofile.Profile, error) {
 	if m.profile == nil {
-		return nil, fmt.Errorf("Entitlements Manager has np security profile.")
+		return nil, fmt.Errorf("Entitlement Manager doesn't have a security profile.")
 	}
 
 	return m.profile, nil
@@ -69,11 +69,11 @@ func isValidEntitlement(ent entitlement.Entitlement) (bool, error) {
 	return true, nil
 }
 
-// AddDefault() adds a default entitlement identified by the "
+// AddDefault() adds a default entitlement identified by entName which must be a default identifier.
 func (m *EntitlementsManager) AddDefault(entName string) error {
 	defaultEnt, ok := defaults.DefaultEntitlements[entName]
 	if !ok {
-		return fmt.Errorf("Couldn't add invalid default entitlement name")
+		return fmt.Errorf("Couldn't add invalid default entitlement name: %s", entName)
 	}
 
 	return m.Add(defaultEnt)

--- a/libentitlement_test.go
+++ b/libentitlement_test.go
@@ -11,7 +11,7 @@ import (
 
 func testSpec() *specs.Spec {
 	s := &specs.Spec{
-		Process: &specs.Process{
+		Process: specs.Process{
 			Capabilities: &specs.LinuxCapabilities{
 				Bounding:    []string{},
 				Effective:   []string{},

--- a/security-profile/helpers.go
+++ b/security-profile/helpers.go
@@ -15,7 +15,7 @@ func addCapToList(capList []string, capToAdd string) []string {
 func removeCapFromList(capList []string, capToRemove string) []string {
 	for index, cap := range capList {
 		if cap == capToRemove {
-			return append(capList[:index], capList[index+1])
+			return append(capList[:index], capList[index+1:]...)
 		}
 	}
 

--- a/security-profile/security_profile.go
+++ b/security-profile/security_profile.go
@@ -86,6 +86,7 @@ func (p *Profile) AddNamespaces(nsTypes ...specs.LinuxNamespaceType) {
 
 /* Add seccomp rules to block syscalls with the given arguments and remove them from allowed/debug rules if present */
 func (p *Profile) BlockSyscallsWithArgs(syscallsWithArgsToBlock map[string][]specs.LinuxSeccompArg) {
+	defaultActError := (p.Oci.Linux.Seccomp.DefaultAction == specs.ActErrno)
 	/* For each syscall to block we browse each syscall list of each Seccomp rule */
 	for syscallNameToBlock, syscallArgsToBlock := range syscallsWithArgsToBlock {
 		blocked := false
@@ -134,7 +135,7 @@ func (p *Profile) BlockSyscallsWithArgs(syscallsWithArgsToBlock map[string][]spe
 		}
 
 		/* If we don't find it in a blocking rule, we add one */
-		if !blocked {
+		if !blocked && !defaultActError {
 			newRule := specs.LinuxSyscall{
 				Names:  []string{syscallNameToBlock},
 				Action: specs.ActErrno,

--- a/security-profile/security_profile.go
+++ b/security-profile/security_profile.go
@@ -105,9 +105,9 @@ func (p *Profile) AllowSyscallsWithArgs(syscallsWithArgsToAllow map[string][]spe
 
 		if defaultActError {
 			newRule := specs.LinuxSyscall{
-				Names: []string{syscallNameToAllow},
+				Names:  []string{syscallNameToAllow},
 				Action: specs.ActAllow,
-				Args:  syscallArgsToAllow,
+				Args:   syscallArgsToAllow,
 			}
 			p.Oci.Linux.Seccomp.Syscalls = append(p.Oci.Linux.Seccomp.Syscalls, newRule)
 		}
@@ -129,7 +129,7 @@ func (p *Profile) BlockSyscallsWithArgs(syscallsWithArgsToBlock map[string][]spe
 					/* We found the syscall in the syscall list in a rule and arguments are identical */
 					if syscallName == syscallNameToBlock &&
 						((len(syscallArgsToBlock) == 0 && len(syscallRule.Args) == 0) ||
-						reflect.DeepEqual(syscallRule.Args, syscallArgsToBlock)) {
+							reflect.DeepEqual(syscallRule.Args, syscallArgsToBlock)) {
 
 						/* If this is the only one, just remove that rule from the Seccomp config */
 						if len(p.Oci.Linux.Seccomp.Syscalls[syscallRuleIndex].Names) == 1 {

--- a/vendor.conf
+++ b/vendor.conf
@@ -1,6 +1,6 @@
 github.com/Sirupsen/logrus 5b60b3d3ee017ed00bcd0225fcca7acab767844b
 github.com/davecgh/go-spew 346938d642f2ec3594ed81d874461961cd0faa76
-github.com/opencontainers/runtime-spec 1259a08e003658f8c4094a6bbc9f52aee29c95df
+github.com/opencontainers/runtime-spec d42f1eb741e6361e858d83fc75aa6893b66292c4
 github.com/pmezard/go-difflib 792786c7400a136282c1664665ae0a8db921c6c2
 github.com/stretchr/testify 4d4bfba8f1d1027c4fdbe371823030df51419987
 golang.org/x/sys 9ccfe848b9db8435a24c424abbc07a921adf1df5

--- a/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
+++ b/vendor/github.com/opencontainers/runtime-spec/specs-go/config.go
@@ -9,7 +9,7 @@ type Spec struct {
 	// Platform specifies the configuration's target platform.
 	Platform Platform `json:"platform"`
 	// Process configures the container process.
-	Process *Process `json:"process,omitempty"`
+	Process Process `json:"process"`
 	// Root configures the container's root filesystem.
 	Root Root `json:"root"`
 	// Hostname configures the container's hostname.
@@ -21,11 +21,11 @@ type Spec struct {
 	// Annotations contains arbitrary metadata for the container.
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	// Linux is platform-specific configuration for Linux based containers.
+	// Linux is platform specific configuration for Linux based containers.
 	Linux *Linux `json:"linux,omitempty" platform:"linux"`
-	// Solaris is platform-specific configuration for Solaris containers.
+	// Solaris is platform specific configuration for Solaris containers.
 	Solaris *Solaris `json:"solaris,omitempty" platform:"solaris"`
-	// Windows is platform-specific configuration for Windows based containers, including Hyper-V containers.
+	// Windows is platform specific configuration for Windows based containers, including Hyper-V containers.
 	Windows *Windows `json:"windows,omitempty" platform:"windows"`
 }
 
@@ -34,7 +34,7 @@ type Process struct {
 	// Terminal creates an interactive terminal for the container.
 	Terminal bool `json:"terminal,omitempty"`
 	// ConsoleSize specifies the size of the console.
-	ConsoleSize *Box `json:"consoleSize,omitempty"`
+	ConsoleSize Box `json:"consoleSize,omitempty"`
 	// User specifies user information for the process.
 	User User `json:"user"`
 	// Args specifies the binary and arguments for the application to execute.
@@ -52,8 +52,6 @@ type Process struct {
 	NoNewPrivileges bool `json:"noNewPrivileges,omitempty" platform:"linux"`
 	// ApparmorProfile specifies the apparmor profile for the container.
 	ApparmorProfile string `json:"apparmorProfile,omitempty" platform:"linux"`
-	// Specify an oom_score_adj for the container.
-	OOMScoreAdj *int `json:"oomScoreAdj,omitempty"`
 	// SelinuxLabel specifies the selinux context that the container process is run as.
 	SelinuxLabel string `json:"selinuxLabel,omitempty" platform:"linux"`
 }
@@ -142,7 +140,7 @@ type Hooks struct {
 	Poststop []Hook `json:"poststop,omitempty"`
 }
 
-// Linux contains platform-specific configuration for Linux based containers.
+// Linux contains platform specific configuration for Linux based containers.
 type Linux struct {
 	// UIDMapping specifies user mappings for supporting user namespaces on Linux.
 	UIDMappings []LinuxIDMapping `json:"uidMappings,omitempty"`
@@ -295,7 +293,7 @@ type LinuxMemory struct {
 	Kernel *uint64 `json:"kernel,omitempty"`
 	// Kernel memory limit for tcp (in bytes)
 	KernelTCP *uint64 `json:"kernelTCP,omitempty"`
-	// How aggressive the kernel will swap memory pages.
+	// How aggressive the kernel will swap memory pages. Range from 0 to 100.
 	Swappiness *uint64 `json:"swappiness,omitempty"`
 }
 
@@ -337,6 +335,8 @@ type LinuxResources struct {
 	Devices []LinuxDeviceCgroup `json:"devices,omitempty"`
 	// DisableOOMKiller disables the OOM killer for out of memory conditions
 	DisableOOMKiller *bool `json:"disableOOMKiller,omitempty"`
+	// Specify an oom_score_adj for the container.
+	OOMScoreAdj *int `json:"oomScoreAdj,omitempty"`
 	// Memory restriction configuration
 	Memory *LinuxMemory `json:"memory,omitempty"`
 	// CPU resource restriction configuration
@@ -383,7 +383,7 @@ type LinuxDeviceCgroup struct {
 	Access string `json:"access,omitempty"`
 }
 
-// Solaris contains platform-specific configuration for Solaris application containers.
+// Solaris contains platform specific configuration for Solaris application containers.
 type Solaris struct {
 	// SMF FMRI which should go "online" before we start the container process.
 	Milestone string `json:"milestone,omitempty"`
@@ -450,13 +450,15 @@ type WindowsResources struct {
 type WindowsMemoryResources struct {
 	// Memory limit in bytes.
 	Limit *uint64 `json:"limit,omitempty"`
+	// Memory reservation in bytes.
+	Reservation *uint64 `json:"reservation,omitempty"`
 }
 
 // WindowsCPUResources contains CPU resource management settings.
 type WindowsCPUResources struct {
 	// Number of CPUs available to the container.
 	Count *uint64 `json:"count,omitempty"`
-	// CPU shares (relative weight to other containers with cpu shares).
+	// CPU shares (relative weight to other containers with cpu shares). Range is from 1 to 10000.
 	Shares *uint16 `json:"shares,omitempty"`
 	// Specifies the portion of processor cycles that this container can use as a percentage times 100.
 	Maximum *uint16 `json:"maximum,omitempty"`


### PR DESCRIPTION
The end-to-end POC is composed of:
- `libentitlement`: the branch used for this PR
- `Moby`: https://github.com/n4ss/moby/tree/poc-entitlements
- `docker CLI`: https://github.com/n4ss/cli/tree/entitlements-poc

Here is a changelist in this PR:
- Expose the network entitlements IDs (strings identifiers)
- Do not export entitlement enforcement callbacks
- Fix `network.none` entitlement to allow calls to `socket` for `Unix sockets`
- Fix  `network.user` entitlement to allow `bpf` and disallow setsockopt for `SO_DEBUG` sockets
- Add getter/setter to `EntitlementManager` for the security profile
- Add a function to enforce default entitlements on the security profile
- Add a function to allow a set of syscalls with their corresponding arguments in the seccomp profile
- Update vendored OCI spec version to Moby's