### PR TITLE
lint: add golint to linting suite, cleanup imports too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,10 @@
 # run all lint functionality - excludes vendoring
 lint:
-	@echo "+ $@: gofmt, govet, gocyclo, misspell, ineffassign"
+	@echo "+ $@: gofmt, golint, govet, gocyclo, misspell, ineffassign"
 	# gofmt
 	@test -z "$$(gofmt -s -l .| grep -v .pb. | grep -v vendor/ | tee /dev/stderr)"
+	# golint
+	@test -z "$(shell find . -type f -name "*.go" -not -path "./vendor/*" -not -name "*.pb.*" -exec golint {} \; | tee /dev/stderr)"
 	# govet
 	@test -z "$$(go tool vet -printf=false . 2>&1 | grep -v vendor/ | tee /dev/stderr)"
 	# gocyclo - we require cyclomatic complexity to be < 16

--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -2,9 +2,10 @@ package defaults
 
 import "github.com/docker/libentitlement/entitlement"
 
+// DefaultEntitlements are the pre-defined entitlements to be consumed by default from libentitlement
 var DefaultEntitlements = map[string]entitlement.Entitlement{
-	NetworkNoneEntFullId:  entitlement.Entitlement(networkNoneEntitlement),
-	NetworkUserEntFullId:  entitlement.Entitlement(networkUserEntitlement),
-	NetworkProxyEntFullId: entitlement.Entitlement(networkProxyEntitlement),
-	NetworkAdminEntFullId: entitlement.Entitlement(networkAdminEntitlement),
+	NetworkNoneEntFullID:  entitlement.Entitlement(networkNoneEntitlement),
+	NetworkUserEntFullID:  entitlement.Entitlement(networkUserEntitlement),
+	NetworkProxyEntFullID: entitlement.Entitlement(networkProxyEntitlement),
+	NetworkAdminEntFullID: entitlement.Entitlement(networkAdminEntitlement),
 }

--- a/defaults/network-ents.go
+++ b/defaults/network-ents.go
@@ -1,10 +1,12 @@
 package defaults
 
 import (
-	"github.com/docker/libentitlement/entitlement"
-	secProfile "github.com/docker/libentitlement/security-profile"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"syscall"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/docker/libentitlement/entitlement"
+	secprofile "github.com/docker/libentitlement/secprofile"
 )
 
 const (
@@ -12,17 +14,21 @@ const (
 )
 
 const (
-	NetworkNoneEntFullId  = networkDomain + ".none"
-	NetworkUserEntFullId  = networkDomain + ".user"
-	NetworkProxyEntFullId = networkDomain + ".proxy"
-	NetworkAdminEntFullId = networkDomain + ".admin"
+	// NetworkNoneEntFullID is the ID for the network.none entitlement
+	NetworkNoneEntFullID = networkDomain + ".none"
+	// NetworkUserEntFullID is the ID for the network.user entitlement
+	NetworkUserEntFullID = networkDomain + ".user"
+	// NetworkProxyEntFullID is the ID for the network.proxy entitlement
+	NetworkProxyEntFullID = networkDomain + ".proxy"
+	// NetworkAdminEntFullID is the ID for the network.admin entitlement
+	NetworkAdminEntFullID = networkDomain + ".admin"
 )
 
 var (
-	networkNoneEntitlement  = entitlement.NewVoidEntitlement(NetworkNoneEntFullId, networkNoneEntitlementEnforce)
-	networkUserEntitlement  = entitlement.NewVoidEntitlement(NetworkUserEntFullId, networkUserEntitlementEnforce)
-	networkProxyEntitlement = entitlement.NewVoidEntitlement(NetworkProxyEntFullId, networkProxyEntitlementEnforce)
-	networkAdminEntitlement = entitlement.NewVoidEntitlement(NetworkAdminEntFullId, networkAdminEntitlementEnforce)
+	networkNoneEntitlement  = entitlement.NewVoidEntitlement(NetworkNoneEntFullID, networkNoneEntitlementEnforce)
+	networkUserEntitlement  = entitlement.NewVoidEntitlement(NetworkUserEntFullID, networkUserEntitlementEnforce)
+	networkProxyEntitlement = entitlement.NewVoidEntitlement(NetworkProxyEntFullID, networkProxyEntitlementEnforce)
+	networkAdminEntitlement = entitlement.NewVoidEntitlement(NetworkAdminEntFullID, networkAdminEntitlementEnforce)
 )
 
 /* Implements "network.none" entitlement
@@ -34,7 +40,7 @@ var (
  *     setdomainname, socket for non AF_LOCAL/AF_UNIX domain
  * - Add network namespace
  */
-func networkNoneEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkNoneEntitlementEnforce(profile *secprofile.Profile) (*secprofile.Profile, error) {
 	capsToRemove := []string{"CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE", "CAP_NET_RAW", "CAP_NET_BROADCAST"}
 	profile.RemoveCaps(capsToRemove...)
 
@@ -77,7 +83,7 @@ func networkNoneEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Pro
  * - Blocked syscalls:
  * 	sethostname, setdomainname, setsockopt(SO_DEBUG)
  */
-func networkUserEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkUserEntitlementEnforce(profile *secprofile.Profile) (*secprofile.Profile, error) {
 	capsToRemove := []string{"CAP_NET_ADMIN", "CAP_NET_BIND_SERVICE", "CAP_NET_RAW"}
 	profile.RemoveCaps(capsToRemove...)
 
@@ -109,7 +115,7 @@ func networkUserEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Pro
  * - Blocked syscalls:
  * 	setsockopt(SO_DEBUG)
  */
-func networkProxyEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkProxyEntitlementEnforce(profile *secprofile.Profile) (*secprofile.Profile, error) {
 	capsToRemove := []string{"CAP_NET_ADMIN"}
 	profile.RemoveCaps(capsToRemove...)
 
@@ -134,7 +140,7 @@ func networkProxyEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Pr
 /* Implements "network.admin" entitlement
  * - Authorized caps: CAP_NET_ADMIN, CAP_NET_BROADCAST, CAP_NET_RAW, CAP_NET_BIND_SERVICE
  */
-func networkAdminEntitlementEnforce(profile *secProfile.Profile) (*secProfile.Profile, error) {
+func networkAdminEntitlementEnforce(profile *secprofile.Profile) (*secprofile.Profile, error) {
 	capsToAdd := []string{"CAP_NET_BROADCAST", "CAP_NET_RAW", "CAP_NET_BIND_SERVICE", "CAP_NET_ADMIN"}
 	profile.AddCaps(capsToAdd...)
 

--- a/entitlement/entitlement.go
+++ b/entitlement/entitlement.go
@@ -1,7 +1,7 @@
 package entitlement
 
 import (
-	secprofile "github.com/docker/libentitlement/security-profile"
+	secprofile "github.com/docker/libentitlement/secprofile"
 )
 
 // FIXME: we should have a hierarchy in domains
@@ -12,6 +12,8 @@ import (
 
 // FIXME: create error objects
 // FIXME: add a method to return domain as a list and one as a string (currently string only)
+
+// Entitlement defines an interface for an entitlement, including its ID, Domain, and how its enforced in a Profile
 type Entitlement interface {
 	// Entitlement's domain name (ex: network, host.devices,
 	Domain() (string, error)

--- a/entitlement/int_entitlements.go
+++ b/entitlement/int_entitlements.go
@@ -2,25 +2,28 @@ package entitlement
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
-	"github.com/docker/libentitlement/parser"
-	secprofile "github.com/docker/libentitlement/security-profile"
 	"strconv"
 	"strings"
+
+	"github.com/Sirupsen/logrus"
+
+	"github.com/docker/libentitlement/parser"
+	secprofile "github.com/docker/libentitlement/secprofile"
 )
 
-// Int entitlement's enforcement callback should take the security profile to update with the constraints and
+// IntEntitlementEnforceCallback should take the security profile to update with the constraints and
 // the entitlement int value as a parameter when being executed
 type IntEntitlementEnforceCallback func(*secprofile.Profile, int64) (*secprofile.Profile, error)
 
-// Int entitlements are entitlements with an explicit int value
+// IntEntitlement is an entitlement with an explicit int value
 type IntEntitlement struct {
-	domain           []string
-	id               string
-	value            []int64
-	enforce_callback IntEntitlementEnforceCallback
+	domain          []string
+	id              string
+	value           []int64
+	enforceCallback IntEntitlementEnforceCallback
 }
 
+// NewIntEntitlement instantiates a new IntEntitlement
 func NewIntEntitlement(fullName string, callback IntEntitlementEnforceCallback) *IntEntitlement {
 	domain, id, value, err := parser.ParseIntEntitlement(fullName)
 	if err != nil {
@@ -33,10 +36,10 @@ func NewIntEntitlement(fullName string, callback IntEntitlementEnforceCallback) 
 	valueRef := make([]int64, 1)
 	valueRef[0] = int64(value)
 
-	return &IntEntitlement{domain: domain, id: id, value: valueRef, enforce_callback: callback}
+	return &IntEntitlement{domain: domain, id: id, value: valueRef, enforceCallback: callback}
 }
 
-// Domain() returns the entitlement's domain name as a string
+// Domain returns the entitlement's domain name as a string
 func (e *IntEntitlement) Domain() (string, error) {
 	if len(e.domain) == 0 {
 		id, err := e.Identifier()
@@ -50,7 +53,7 @@ func (e *IntEntitlement) Domain() (string, error) {
 	return strings.Join(e.domain, "."), nil
 }
 
-// Identifier() returns the entitlement's identifier
+// Identifier returns the entitlement's identifier
 func (e *IntEntitlement) Identifier() (string, error) {
 	if e.id == "" {
 		return "", fmt.Errorf("No identifier found for current entitlement")
@@ -59,7 +62,7 @@ func (e *IntEntitlement) Identifier() (string, error) {
 	return e.id, nil
 }
 
-// Value() returns the entitlement's value.
+// Value returns the entitlement's value.
 // Note: Int entitlements need an explicit value, it can't be an empty string
 func (e *IntEntitlement) Value() (string, error) {
 	if e.value == nil || len(e.value) == 0 {
@@ -73,7 +76,7 @@ func (e *IntEntitlement) Value() (string, error) {
 	return strValue, nil
 }
 
-// Enforce() calls the enforcement callback which applies the constraints on the security profile
+// Enforce calls the enforcement callback which applies the constraints on the security profile
 // based on the entitlement int value
 func (e *IntEntitlement) Enforce(profile *secprofile.Profile) (*secprofile.Profile, error) {
 	if e.value == nil || len(e.value) == 0 {
@@ -82,13 +85,13 @@ func (e *IntEntitlement) Enforce(profile *secprofile.Profile) (*secprofile.Profi
 		return profile, fmt.Errorf("Invalid value for entitlement %v.%v", domain, id)
 	}
 
-	if e.enforce_callback == nil {
+	if e.enforceCallback == nil {
 		id, _ := e.Identifier()
 		domain, _ := e.Domain()
 		return profile, fmt.Errorf("Invalid enforcement callback for entitlement %v.%v", domain, id)
 	}
 
-	newProfile, err := e.enforce_callback(profile, e.value[1])
+	newProfile, err := e.enforceCallback(profile, e.value[1])
 	if err != nil {
 		return profile, err
 	}

--- a/entitlement/string_entitlements.go
+++ b/entitlement/string_entitlements.go
@@ -2,24 +2,27 @@ package entitlement
 
 import (
 	"fmt"
-	"github.com/Sirupsen/logrus"
-	"github.com/docker/libentitlement/parser"
-	secprofile "github.com/docker/libentitlement/security-profile"
 	"strings"
+
+	"github.com/Sirupsen/logrus"
+
+	"github.com/docker/libentitlement/parser"
+	secprofile "github.com/docker/libentitlement/secprofile"
 )
 
-// String entitlement's enforcement callback should take the security profile to update with the constraints and
+// StringEntitlementEnforceCallback should take the security profile to update with the constraints and
 // the entitlement value as a parameter when being executed
 type StringEntitlementEnforceCallback func(*secprofile.Profile, string) (*secprofile.Profile, error)
 
-// String entitlements are entitlements with an explicit string value
+// StringEntitlement is an entitlements with an explicit string value
 type StringEntitlement struct {
-	domain           []string
-	id               string
-	value            string
-	enforce_callback StringEntitlementEnforceCallback
+	domain          []string
+	id              string
+	value           string
+	enforceCallback StringEntitlementEnforceCallback
 }
 
+// NewStringEntitlement instantiates a new StringEntitlement
 func NewStringEntitlement(fullName string, callback StringEntitlementEnforceCallback) *StringEntitlement {
 	domain, id, value, err := parser.ParseStringEntitlement(fullName)
 	if err != nil {
@@ -29,10 +32,10 @@ func NewStringEntitlement(fullName string, callback StringEntitlementEnforceCall
 
 	// FIXME: Add entitlement domain and the identifier to it
 
-	return &StringEntitlement{domain: domain, id: id, value: value, enforce_callback: callback}
+	return &StringEntitlement{domain: domain, id: id, value: value, enforceCallback: callback}
 }
 
-// Domain() returns the entitlement's domain name
+// Domain returns the entitlement's domain name
 func (e *StringEntitlement) Domain() (string, error) {
 	if len(e.domain) < 1 {
 		id, err := e.Identifier()
@@ -46,7 +49,7 @@ func (e *StringEntitlement) Domain() (string, error) {
 	return strings.Join(e.domain, "."), nil
 }
 
-// Identifier() returns the entitlement's identifier
+// Identifier returns the entitlement's identifier
 func (e *StringEntitlement) Identifier() (string, error) {
 	if e.id == "" {
 		return "", fmt.Errorf("No identifier found for current entitlement")
@@ -55,7 +58,7 @@ func (e *StringEntitlement) Identifier() (string, error) {
 	return e.id, nil
 }
 
-// Value() returns the entitlement's value.
+// Value returns the entitlement's value.
 // Note: String entitlements need an explicit value, it can't be an empty string
 func (e *StringEntitlement) Value() (string, error) {
 	if e.value == "" {
@@ -67,7 +70,7 @@ func (e *StringEntitlement) Value() (string, error) {
 	return e.value, nil
 }
 
-// Enforce() calls the enforcement callback which applies the constraints on the security profile
+// Enforce calls the enforcement callback which applies the constraints on the security profile
 // based on the entitlement value
 func (e *StringEntitlement) Enforce(profile *secprofile.Profile) (*secprofile.Profile, error) {
 	value, err := e.Value()
@@ -75,13 +78,13 @@ func (e *StringEntitlement) Enforce(profile *secprofile.Profile) (*secprofile.Pr
 		return nil, err
 	}
 
-	if e.enforce_callback == nil {
+	if e.enforceCallback == nil {
 		id, _ := e.Identifier()
 		domain, _ := e.Domain()
 		return nil, fmt.Errorf("Invalid enforcement callback for entitlement %v.%v", domain, id)
 	}
 
-	newProfile, err := e.enforce_callback(profile, value)
+	newProfile, err := e.enforceCallback(profile, value)
 	if err != nil {
 		return nil, err
 	}

--- a/libentitlement.go
+++ b/libentitlement.go
@@ -2,21 +2,24 @@ package libentitlement
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/Sirupsen/logrus"
+
 	"github.com/docker/libentitlement/defaults"
 	"github.com/docker/libentitlement/domain"
 	"github.com/docker/libentitlement/entitlement"
-	secprofile "github.com/docker/libentitlement/security-profile"
-	"strings"
+	secprofile "github.com/docker/libentitlement/secprofile"
 )
 
+// EntitlementsManager generates enforceable profiles from its entitlements and domains state
 type EntitlementsManager struct {
 	profile         *secprofile.Profile
 	entitlementList []entitlement.Entitlement
 	domainManager   *domainmanager.DomainManager
 }
 
-// NewEntitlementsManager() instantiates an EntitlementsManager object with the given profile
+// NewEntitlementsManager instantiates an EntitlementsManager object with the given profile
 // default
 func NewEntitlementsManager(profile *secprofile.Profile) *EntitlementsManager {
 	if profile == nil {
@@ -31,16 +34,16 @@ func NewEntitlementsManager(profile *secprofile.Profile) *EntitlementsManager {
 	}
 }
 
-// GetProfile() returns the current state of the security profile
+// GetProfile returns the current state of the security profile
 func (m *EntitlementsManager) GetProfile() (*secprofile.Profile, error) {
 	if m.profile == nil {
-		return nil, fmt.Errorf("Entitlements Manager doesn't have a security profile.")
+		return nil, fmt.Errorf("Entitlements Manager doesn't have a security profile")
 	}
 
 	return m.profile, nil
 }
 
-// SetProfile() sets the entitlement manager's security profile
+// SetProfile sets the entitlement manager's security profile
 func (m *EntitlementsManager) SetProfile(profile *secprofile.Profile) error {
 	if profile == nil {
 		return fmt.Errorf("Invalid security profile")
@@ -69,7 +72,7 @@ func isValidEntitlement(ent entitlement.Entitlement) (bool, error) {
 	return true, nil
 }
 
-// AddDefault() adds a default entitlement identified by entName which must be a default identifier.
+// AddDefault adds a default entitlement identified by entName which must be a default identifier.
 func (m *EntitlementsManager) AddDefault(entName string) error {
 	defaultEnt, ok := defaults.DefaultEntitlements[entName]
 	if !ok {
@@ -79,7 +82,7 @@ func (m *EntitlementsManager) AddDefault(entName string) error {
 	return m.Add(defaultEnt)
 }
 
-// Add() adds the given entitlements to the current entitlements list, updates the domain name system and enforce
+// Add adds the given entitlements to the current entitlements list, updates the domain name system and enforce
 // the entitlement on the security profile
 func (m *EntitlementsManager) Add(entitlements ...entitlement.Entitlement) error {
 	if m.profile == nil {
@@ -100,7 +103,7 @@ func (m *EntitlementsManager) Add(entitlements ...entitlement.Entitlement) error
 		domainString, _ := ent.Domain()
 		domainList := strings.Split(domainString, ".")
 
-		err = m.domainManager.AddFullDomainWithEntitlementId(domainList, identifier)
+		err = m.domainManager.AddFullDomainWithEntitlementID(domainList, identifier)
 		if err != nil {
 			// Should not happen since we verified isValidEntitlement
 			// FIXME: we should probably revert the changes on the security profile
@@ -149,7 +152,7 @@ func isEqual(ent1, ent2 entitlement.Entitlement) (bool, error) {
 	return id1 == id2 && dom1 == dom2 && val1 == val2, nil
 }
 
-// HasEntitlement() returns wether the given entitlement is registered in the current entitlements list
+// HasEntitlement returns whether the given entitlement is registered in the current entitlements list
 func (m *EntitlementsManager) HasEntitlement(ent entitlement.Entitlement) (bool, error) {
 	if isValid, err := isValidEntitlement(ent); isValid == false {
 		return false, fmt.Errorf("Couldn't check  invalid entitlement: %v", err)
@@ -170,7 +173,7 @@ func (m *EntitlementsManager) HasEntitlement(ent entitlement.Entitlement) (bool,
 	return false, nil
 }
 
-// Enforce() applies the constraints on the security profile and updates it to be used for the container
+// Enforce applies the constraints on the security profile and updates it to be used for the container
 func (m *EntitlementsManager) Enforce() error {
 	for _, ent := range m.entitlementList {
 		if isValid, err := isValidEntitlement(ent); isValid == false {

--- a/libentitlement_test.go
+++ b/libentitlement_test.go
@@ -2,11 +2,13 @@ package libentitlement
 
 import (
 	"fmt"
-	"github.com/docker/libentitlement/entitlement"
-	secprofile "github.com/docker/libentitlement/security-profile"
+	"testing"
+
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
-	"testing"
+
+	"github.com/docker/libentitlement/entitlement"
+	secprofile "github.com/docker/libentitlement/secprofile"
 )
 
 func testSpec() *specs.Spec {
@@ -47,7 +49,7 @@ func TestRegisterDummyEntitlement(t *testing.T) {
 	// Add a dummy "foo.bar.cap-sys-admin" void entitlement that adds CAP_SYS_ADMIN
 	capSysAdminVoidEntCallback := func(profile *secprofile.Profile) (*secprofile.Profile, error) {
 		if profile == nil {
-			return nil, fmt.Errorf("CapSysAdminVoidEntCallback - profile is nil.")
+			return nil, fmt.Errorf("CapSysAdminVoidEntCallback - profile is nil")
 		}
 
 		profile.AddCaps("CAP_SYS_ADMIN")
@@ -62,8 +64,8 @@ func TestRegisterDummyEntitlement(t *testing.T) {
 	err := entMgr.Add(capSysAdminVoidEnt)
 	require.NoError(t, err, "Entitlement %s should have been added and enforced", capSysAdminVoidEntFullName)
 
-	require.Contains(t, profile.Oci.Process.Capabilities.Bounding, "CAP_SYS_ADMIN", "Capability is missing after entitlement enforcement")
-	require.Contains(t, profile.Oci.Process.Capabilities.Effective, "CAP_SYS_ADMIN", "Capability is missing after entitlement enforcement")
-	require.Contains(t, profile.Oci.Process.Capabilities.Permitted, "CAP_SYS_ADMIN", "Capability is missing after entitlement enforcement")
-	require.Contains(t, profile.Oci.Process.Capabilities.Inheritable, "CAP_SYS_ADMIN", "Capability is missing after entitlement enforcement")
+	require.Contains(t, profile.OCI.Process.Capabilities.Bounding, "CAP_SYS_ADMIN", "Capability is missing after entitlement enforcement")
+	require.Contains(t, profile.OCI.Process.Capabilities.Effective, "CAP_SYS_ADMIN", "Capability is missing after entitlement enforcement")
+	require.Contains(t, profile.OCI.Process.Capabilities.Permitted, "CAP_SYS_ADMIN", "Capability is missing after entitlement enforcement")
+	require.Contains(t, profile.OCI.Process.Capabilities.Inheritable, "CAP_SYS_ADMIN", "Capability is missing after entitlement enforcement")
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -10,13 +10,15 @@ import (
 // FIXME: refactor shared code between each Parse[..]Entitlement functions
 // FIXME: create error objects
 
-// Matches alphanum string containing alphanum substrings separated by single dashes
+// isAlphanumOrDash is a regex matching alphanum string containing alphanum substrings separated by single dashes
 var isAlphanumOrDash = regexp.MustCompile(`^[a-zA-Z0-9]+(\-[a-zA-Z0-9]+)*$`).MatchString
 
+// IsValidDomainName returns whether a given string is a valid domain name
 func IsValidDomainName(domain string) bool {
 	return isAlphanumOrDash(domain)
 }
 
+// IsValidDomainNameList returns whether the list of domain names contains all valid domain names
 func IsValidDomainNameList(domain []string) bool {
 	for _, domainField := range domain {
 		if IsValidDomainName(domainField) == false {
@@ -27,11 +29,12 @@ func IsValidDomainNameList(domain []string) bool {
 	return true
 }
 
+// IsValidIdentifier returns whether the given string is a valid identifier
 func IsValidIdentifier(identifier string) bool {
 	return isAlphanumOrDash(identifier)
 }
 
-// ParseVoidEntitlement() parses an entitlement with the following format: "domain-name.identifier"
+// ParseVoidEntitlement parses an entitlement with the following format: "domain-name.identifier"
 func ParseVoidEntitlement(entitlementFormat string) (domain []string, id string, err error) {
 	stringList := strings.Split(entitlementFormat, ".")
 	if len(stringList) < 2 {
@@ -52,7 +55,7 @@ func ParseVoidEntitlement(entitlementFormat string) (domain []string, id string,
 	return
 }
 
-// ParseIntEntitlement() parses an entitlement with the following format: "domain-name.identifier=int64-value"
+// ParseIntEntitlement parses an entitlement with the following format: "domain-name.identifier=int64-value"
 func ParseIntEntitlement(entitlementFormat string) (domain []string, id string, value int, err error) {
 	stringList := strings.Split(entitlementFormat, ".")
 	if len(stringList) < 2 {
@@ -86,7 +89,7 @@ func ParseIntEntitlement(entitlementFormat string) (domain []string, id string, 
 	return
 }
 
-// ParseStringEntitlement() parses an entitlement with the following format: "domain-name.identifier=string-value"
+// ParseStringEntitlement parses an entitlement with the following format: "domain-name.identifier=string-value"
 func ParseStringEntitlement(entitlementFormat string) (domain []string, id, value string, err error) {
 	stringList := strings.Split(entitlementFormat, ".")
 	if len(stringList) < 2 {

--- a/secprofile/helpers.go
+++ b/secprofile/helpers.go
@@ -1,4 +1,4 @@
-package security_profile
+package secprofile
 
 /* Add capability if not present to capability set */
 func addCapToList(capList []string, capToAdd string) []string {

--- a/secprofile/security_profile.go
+++ b/secprofile/security_profile.go
@@ -1,10 +1,11 @@
-package security_profile
+package secprofile
 
 import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"reflect"
 )
 
+// AppArmorProfile defines a list of AppArmor rules to enforce
 type AppArmorProfile struct {
 	Rules []string
 }
@@ -15,45 +16,46 @@ type AppArmorProfile struct {
 // FIXME: Add error handling here if profile or subfields are not allocated */
 // Fixme add api access settings for Engine / Swarm / K8s?
 type Profile struct {
-	Oci      *specs.Spec
+	OCI      *specs.Spec
 	AppArmor *AppArmorProfile
 }
 
-func NewProfile(ociSpec *specs.Spec) *Profile {
-	return &Profile{Oci: ociSpec}
+// NewProfile instantiates a new Profile
+func NewProfile(OCISpec *specs.Spec) *Profile {
+	return &Profile{OCI: OCISpec}
 }
 
-/* Add a list of capabilities if not present to all capability masks */
+// AddCaps adds a list of capabilities if not present to all capability masks
 func (p *Profile) AddCaps(capsToAdd ...string) {
 	for _, cap := range capsToAdd {
-		p.Oci.Process.Capabilities.Bounding = addCapToList(p.Oci.Process.Capabilities.Bounding, cap)
-		p.Oci.Process.Capabilities.Effective = addCapToList(p.Oci.Process.Capabilities.Effective, cap)
-		p.Oci.Process.Capabilities.Inheritable = addCapToList(p.Oci.Process.Capabilities.Inheritable, cap)
-		p.Oci.Process.Capabilities.Permitted = addCapToList(p.Oci.Process.Capabilities.Permitted, cap)
+		p.OCI.Process.Capabilities.Bounding = addCapToList(p.OCI.Process.Capabilities.Bounding, cap)
+		p.OCI.Process.Capabilities.Effective = addCapToList(p.OCI.Process.Capabilities.Effective, cap)
+		p.OCI.Process.Capabilities.Inheritable = addCapToList(p.OCI.Process.Capabilities.Inheritable, cap)
+		p.OCI.Process.Capabilities.Permitted = addCapToList(p.OCI.Process.Capabilities.Permitted, cap)
 
 		// Should be updated automatically if the previous masks are set
-		p.Oci.Process.Capabilities.Ambient = addCapToList(p.Oci.Process.Capabilities.Ambient, cap)
+		p.OCI.Process.Capabilities.Ambient = addCapToList(p.OCI.Process.Capabilities.Ambient, cap)
 	}
 }
 
-/* Remove a list of capabilities if present from all capability masks */
+// RemoveCaps removes a list of capabilities if present from all capability masks
 func (p *Profile) RemoveCaps(capsToRemove ...string) {
 	for _, cap := range capsToRemove {
-		p.Oci.Process.Capabilities.Bounding = removeCapFromList(p.Oci.Process.Capabilities.Bounding, cap)
-		p.Oci.Process.Capabilities.Effective = removeCapFromList(p.Oci.Process.Capabilities.Effective, cap)
-		p.Oci.Process.Capabilities.Inheritable = removeCapFromList(p.Oci.Process.Capabilities.Inheritable, cap)
-		p.Oci.Process.Capabilities.Permitted = removeCapFromList(p.Oci.Process.Capabilities.Permitted, cap)
+		p.OCI.Process.Capabilities.Bounding = removeCapFromList(p.OCI.Process.Capabilities.Bounding, cap)
+		p.OCI.Process.Capabilities.Effective = removeCapFromList(p.OCI.Process.Capabilities.Effective, cap)
+		p.OCI.Process.Capabilities.Inheritable = removeCapFromList(p.OCI.Process.Capabilities.Inheritable, cap)
+		p.OCI.Process.Capabilities.Permitted = removeCapFromList(p.OCI.Process.Capabilities.Permitted, cap)
 
 		// Should be updated automatically if the previous masks are set
-		p.Oci.Process.Capabilities.Ambient = removeCapFromList(p.Oci.Process.Capabilities.Ambient, cap)
+		p.OCI.Process.Capabilities.Ambient = removeCapFromList(p.OCI.Process.Capabilities.Ambient, cap)
 	}
 }
 
-/* Add a list of paths to the set of paths masked in the container if not present yet */
+// AddMaskedPaths adds a list of paths to the set of paths masked in the container if not present yet
 func (p *Profile) AddMaskedPaths(pathsToMask ...string) {
 	for _, dir := range pathsToMask {
 		exists := false
-		for _, paths := range p.Oci.Linux.MaskedPaths {
+		for _, paths := range p.OCI.Linux.MaskedPaths {
 			if paths == dir {
 				exists = true
 				break
@@ -61,16 +63,16 @@ func (p *Profile) AddMaskedPaths(pathsToMask ...string) {
 		}
 
 		if !exists {
-			p.Oci.Linux.MaskedPaths = append(p.Oci.Linux.MaskedPaths, dir)
+			p.OCI.Linux.MaskedPaths = append(p.OCI.Linux.MaskedPaths, dir)
 		}
 	}
 }
 
-/* Add a list of namespaces to the enabled namespaces */
+// AddNamespaces adds a list of namespaces to the enabled namespaces
 func (p *Profile) AddNamespaces(nsTypes ...specs.LinuxNamespaceType) {
 	for _, ns := range nsTypes {
 		exists := false
-		for _, namespace := range p.Oci.Linux.Namespaces {
+		for _, namespace := range p.OCI.Linux.Namespaces {
 			if namespace.Type == ns {
 				exists = true
 				break
@@ -79,18 +81,18 @@ func (p *Profile) AddNamespaces(nsTypes ...specs.LinuxNamespaceType) {
 
 		if !exists {
 			newNs := specs.LinuxNamespace{Type: ns}
-			p.Oci.Linux.Namespaces = append(p.Oci.Linux.Namespaces, newNs)
+			p.OCI.Linux.Namespaces = append(p.OCI.Linux.Namespaces, newNs)
 		}
 	}
 }
 
-/* Add seccomp rules to allow syscalls with the given arguments if necessary */
+// AllowSyscallsWithArgs adds seccomp rules to allow syscalls with the given arguments if necessary
 func (p *Profile) AllowSyscallsWithArgs(syscallsWithArgsToAllow map[string][]specs.LinuxSeccompArg) {
-	defaultActError := (p.Oci.Linux.Seccomp.DefaultAction == specs.ActErrno)
+	defaultActError := (p.OCI.Linux.Seccomp.DefaultAction == specs.ActErrno)
 
 	/* For each syscall we want to whitelist, we browse each syscall list of each whitelisting Seccomp rule. */
 	for syscallNameToAllow, syscallArgsToAllow := range syscallsWithArgsToAllow {
-		for _, syscallRule := range p.Oci.Linux.Seccomp.Syscalls {
+		for _, syscallRule := range p.OCI.Linux.Seccomp.Syscalls {
 			if syscallRule.Action == specs.ActAllow {
 				for _, syscallName := range syscallRule.Names {
 					/* If we match the syscall for a whitelisting rule and the arguments are the same
@@ -114,19 +116,19 @@ func (p *Profile) AllowSyscallsWithArgs(syscallsWithArgsToAllow map[string][]spe
 				Action: specs.ActAllow,
 				Args:   syscallArgsToAllow,
 			}
-			p.Oci.Linux.Seccomp.Syscalls = append(p.Oci.Linux.Seccomp.Syscalls, newRule)
+			p.OCI.Linux.Seccomp.Syscalls = append(p.OCI.Linux.Seccomp.Syscalls, newRule)
 		}
 	}
 }
 
-/* Add seccomp rules to block syscalls with the given arguments and remove them from allowed/debug rules if present */
+// BlockSyscallsWithArgs adds seccomp rules to block syscalls with the given arguments and remove them from allowed/debug rules if present
 func (p *Profile) BlockSyscallsWithArgs(syscallsWithArgsToBlock map[string][]specs.LinuxSeccompArg) {
-	defaultActError := (p.Oci.Linux.Seccomp.DefaultAction == specs.ActErrno)
+	defaultActError := (p.OCI.Linux.Seccomp.DefaultAction == specs.ActErrno)
 
 	/* For each syscall to block we browse each syscall list of each Seccomp rule */
 	for syscallNameToBlock, syscallArgsToBlock := range syscallsWithArgsToBlock {
 		blocked := false
-		for syscallRuleIndex, syscallRule := range p.Oci.Linux.Seccomp.Syscalls {
+		for syscallRuleIndex, syscallRule := range p.OCI.Linux.Seccomp.Syscalls {
 			switch syscallRule.Action {
 			case specs.ActAllow, specs.ActTrace, specs.ActTrap:
 				for syscallNameIndex, syscallName := range syscallRule.Names {
@@ -136,19 +138,19 @@ func (p *Profile) BlockSyscallsWithArgs(syscallsWithArgsToBlock map[string][]spe
 							reflect.DeepEqual(syscallRule.Args, syscallArgsToBlock)) {
 
 						/* If this is the only one, just remove that rule from the Seccomp config */
-						if len(p.Oci.Linux.Seccomp.Syscalls[syscallRuleIndex].Names) == 1 {
-							p.Oci.Linux.Seccomp.Syscalls = append(
-								p.Oci.Linux.Seccomp.Syscalls[0:syscallRuleIndex],
-								p.Oci.Linux.Seccomp.Syscalls[syscallRuleIndex+1:]...,
+						if len(p.OCI.Linux.Seccomp.Syscalls[syscallRuleIndex].Names) == 1 {
+							p.OCI.Linux.Seccomp.Syscalls = append(
+								p.OCI.Linux.Seccomp.Syscalls[0:syscallRuleIndex],
+								p.OCI.Linux.Seccomp.Syscalls[syscallRuleIndex+1:]...,
 							)
 
 							break
 						}
 
 						/* Otherwise, remove it from the rule */
-						p.Oci.Linux.Seccomp.Syscalls[syscallRuleIndex].Names = append(
-							p.Oci.Linux.Seccomp.Syscalls[syscallRuleIndex].Names[0:syscallNameIndex],
-							p.Oci.Linux.Seccomp.Syscalls[syscallRuleIndex].Names[syscallNameIndex+1:]...,
+						p.OCI.Linux.Seccomp.Syscalls[syscallRuleIndex].Names = append(
+							p.OCI.Linux.Seccomp.Syscalls[syscallRuleIndex].Names[0:syscallNameIndex],
+							p.OCI.Linux.Seccomp.Syscalls[syscallRuleIndex].Names[syscallNameIndex+1:]...,
 						)
 					}
 				}
@@ -176,13 +178,13 @@ func (p *Profile) BlockSyscallsWithArgs(syscallsWithArgsToBlock map[string][]spe
 				Action: specs.ActErrno,
 				Args:   syscallArgsToBlock,
 			}
-			p.Oci.Linux.Seccomp.Syscalls = append(p.Oci.Linux.Seccomp.Syscalls, newRule)
+			p.OCI.Linux.Seccomp.Syscalls = append(p.OCI.Linux.Seccomp.Syscalls, newRule)
 		}
 
 	}
 }
 
-/* Block a list of syscalls without specific arguments */
+// BlockSyscalls blocks a list of syscalls without specific arguments
 func (p *Profile) BlockSyscalls(syscallsToBlock ...string) {
 	syscallsWithNoArgsToBlock := make(map[string][]specs.LinuxSeccompArg)
 	for _, syscallsToBlock := range syscallsToBlock {


### PR DESCRIPTION
Adds `golint` to our test suite, to ensure that code is appropriately commented and organized

cc @stevvooe for the suggestion

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>