### PR TITLE
Add Security Entitlements

### DIFF
--- a/defaults/defaults.go
+++ b/defaults/defaults.go
@@ -8,4 +8,9 @@ var DefaultEntitlements = map[string]entitlement.Entitlement{
 	NetworkUserEntFullID:  entitlement.Entitlement(networkUserEntitlement),
 	NetworkProxyEntFullID: entitlement.Entitlement(networkProxyEntitlement),
 	NetworkAdminEntFullID: entitlement.Entitlement(networkAdminEntitlement),
+
+	SecurityConfinedEntFullID: entitlement.Entitlement(securityConfinedEntitlement),
+	SecurityViewEntFullID:     entitlement.Entitlement(securityViewEntitlement),
+	SecurityAdminEntFullID:    entitlement.Entitlement(securityAdminEntitlement),
+	SecurityMemoryLockFullID:  entitlement.Entitlement(securityMemoryLockEntitlement),
 }

--- a/defaults/osdefs/osdefs_darwin.go
+++ b/defaults/osdefs/osdefs_darwin.go
@@ -1,0 +1,10 @@
+// +build darwin
+
+package osdefs
+
+const (
+	// PrCapbsetDrop is prctl PR_CAPBSET_READ argument value
+	PrCapbsetDrop = 0x18
+	// PrCapbsetRead is prctl PR_CAPBSET_DROP argument value
+	PrCapbsetRead = 0x17
+)

--- a/defaults/osdefs/osdefs_linux.go
+++ b/defaults/osdefs/osdefs_linux.go
@@ -1,0 +1,12 @@
+// +build linux
+
+package osdefs
+
+import "syscall"
+
+const (
+	// PrCapbsetDrop is prctl PR_CAPBSET_READ argument value
+	PrCapbsetDrop = syscall.PR_CAPBSET_READ
+	// PrCapbsetRead is prctl PR_CAPBSET_DROP argument value
+	PrCapbsetRead = syscall.PR_CAPBSET_DROP
+)

--- a/defaults/security-ents.go
+++ b/defaults/security-ents.go
@@ -1,0 +1,162 @@
+package defaults
+
+import (
+	"fmt"
+
+	"github.com/docker/libentitlement/defaults/osdefs"
+	"github.com/docker/libentitlement/entitlement"
+	"github.com/docker/libentitlement/secprofile"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+const (
+	securityDomain = "security"
+)
+
+const (
+	// SecurityConfinedEntFullID is the ID for the security.confined entitlement
+	SecurityConfinedEntFullID = securityDomain + ".confined"
+	// SecurityViewEntFullID is the ID for the security.view entitlement
+	SecurityViewEntFullID = securityDomain + ".view"
+	// SecurityAdminEntFullID is the ID for the security.admin entitlement
+	SecurityAdminEntFullID = securityDomain + ".admin"
+	// SecurityMemoryLockFullID is the ID for the security.memory-lock entitlement
+	SecurityMemoryLockFullID = securityDomain + ".memory-lock"
+)
+
+var (
+	securityConfinedEntitlement   = entitlement.NewVoidEntitlement(SecurityConfinedEntFullID, securityConfinedEntitlementEnforce)
+	securityViewEntitlement       = entitlement.NewVoidEntitlement(SecurityViewEntFullID, securityViewEntitlementEnforce)
+	securityAdminEntitlement      = entitlement.NewVoidEntitlement(SecurityAdminEntFullID, securityAdminEntitlementEnforce)
+	securityMemoryLockEntitlement = entitlement.NewVoidEntitlement(SecurityMemoryLockFullID, securityMemoryLockEnforce)
+)
+
+func securityConfinedEntitlementEnforce(profile secprofile.Profile) (secprofile.Profile, error) {
+	if profile.GetType() != secprofile.OCIProfileType {
+		return nil, fmt.Errorf("%s not implemented for non-OCI profiles", SecurityConfinedEntFullID)
+	}
+
+	ociProfile, ok := profile.(*secprofile.OCIProfile)
+	if !ok {
+		return nil, fmt.Errorf("%s: error converting to OCI profile", SecurityConfinedEntFullID)
+	}
+
+	capsToRemove := []string{"CAP_MAC_ADMIN", "CAP_MAC_OVERRIDE", "CAP_DAC_OVERRIDE", "CAP_DAC_READ_SEARCH",
+		"CAP_SETPCAP", "CAP_SETFCAP", "CAP_SETUID", "CAP_SETGID", "CAP_SYS_PTRACE", "CAP_FSETID", "CAP_SYS_MODULE",
+		"CAP_SYSLOG", "CAP_SYS_RAWIO", "CAP_SYS_ADMIN", "CAP_LINUX_IMMUTABLE",
+	}
+	ociProfile.RemoveCaps(capsToRemove...)
+
+	syscallsToBlock := []string{"ptrace", "arch_prctl", "personality", "setuid", "setgid", "prctl",
+		"madvise",
+	}
+	ociProfile.BlockSyscalls(syscallsToBlock...)
+
+	syscallsWithArgsToAllow := map[string][]specs.LinuxSeccompArg{
+		"prctl": {
+			{
+				Index: 0,
+				Value: osdefs.PrCapbsetDrop,
+				Op:    specs.OpNotEqual,
+			},
+			{
+				Index: 0,
+				Value: osdefs.PrCapbsetRead,
+				Op:    specs.OpNotEqual,
+			},
+		},
+	}
+	ociProfile.AllowSyscallsWithArgs(syscallsWithArgsToAllow)
+
+	/* FIXME: Add AppArmor rules to deny RW on sensitive FS directories */
+
+	return ociProfile, nil
+}
+
+func securityViewEntitlementEnforce(profile secprofile.Profile) (secprofile.Profile, error) {
+	if profile.GetType() != secprofile.OCIProfileType {
+		return nil, fmt.Errorf("%s not implemented for non-OCI profiles", SecurityViewEntFullID)
+	}
+
+	ociProfile, ok := profile.(*secprofile.OCIProfile)
+	if !ok {
+		return nil, fmt.Errorf("%s: error converting to OCI profile", SecurityViewEntFullID)
+	}
+
+	capsToRemove := []string{"CAP_SYS_ADMIN", "CAP_SYS_PTRACE", "CAP_SETUID", "CAP_SETGID", "CAP_SETPCAP",
+		"CAP_SETFCAP", "CAP_MAC_ADMIN", "CAP_MAC_OVERRIDE", "CAP_DAC_OVERRIDE", "CAP_FSETID",
+		"CAP_SYS_MODULE", "CAP_SYSLOG", "CAP_SYS_RAWIO", "CAP_LINUX_IMMUTABLE",
+	}
+	ociProfile.RemoveCaps(capsToRemove...)
+
+	capsToAdd := []string{"CAP_DAC_READ_SEARCH"}
+	ociProfile.AddCaps(capsToAdd...)
+
+	syscallsToBlock := []string{"ptrace", "arch_prctl", "personality", "setuid", "setgid", "prctl",
+		"madvise",
+	}
+	ociProfile.BlockSyscalls(syscallsToBlock...)
+
+	syscallsWithArgsToAllow := map[string][]specs.LinuxSeccompArg{
+		"prctl": {
+			{
+				Index: 0,
+				Value: osdefs.PrCapbsetDrop,
+				Op:    specs.OpNotEqual,
+			},
+		},
+	}
+	ociProfile.AllowSyscallsWithArgs(syscallsWithArgsToAllow)
+
+	/* FIXME: Add AppArmor rules to RO on sensitive FS directories */
+
+	return ociProfile, nil
+}
+
+func securityAdminEntitlementEnforce(profile secprofile.Profile) (secprofile.Profile, error) {
+	if profile.GetType() != secprofile.OCIProfileType {
+		return nil, fmt.Errorf("%s not implemented for non-OCI profiles", SecurityAdminEntFullID)
+	}
+
+	ociProfile, ok := profile.(*secprofile.OCIProfile)
+	if !ok {
+		return nil, fmt.Errorf("%s: error converting to OCI profile", SecurityAdminEntFullID)
+	}
+
+	capsToAdd := []string{
+		"CAP_MAC_ADMIN", "CAP_MAC_OVERRIDE", "CAP_DAC_OVERRIDE", "CAP_DAC_READ_SEARCH",
+		"CAP_SETPCAP", "CAP_SETFCAP", "CAP_SETUID", "CAP_SETGID", "CAP_SYS_PTRACE", "CAP_FSETID", "CAP_SYS_MODULE",
+		"CAP_SYSLOG", "CAP_SYS_RAWIO", "CAP_SYS_ADMIN", "CAP_LINUX_IMMUTABLE",
+	}
+	ociProfile.AddCaps(capsToAdd...)
+
+	syscallsToAllow := []string{"ptrace", "arch_prctl", "personality", "setuid", "setgid", "prctl",
+		"madvise",
+	}
+	ociProfile.AllowSyscalls(syscallsToAllow...)
+
+	return ociProfile, nil
+}
+
+func securityMemoryLockEnforce(profile secprofile.Profile) (secprofile.Profile, error) {
+	if profile.GetType() != secprofile.OCIProfileType {
+		return nil, fmt.Errorf("%s not implemented for non-OCI profiles", SecurityMemoryLockFullID)
+	}
+
+	ociProfile, ok := profile.(*secprofile.OCIProfile)
+	if !ok {
+		return nil, fmt.Errorf("%s: error converting to OCI profile", SecurityMemoryLockFullID)
+	}
+
+	capsToAdd := []string{
+		"CAP_IPC_LOCK",
+	}
+	ociProfile.AddCaps(capsToAdd...)
+
+	syscallsToAllow := []string{
+		"mlock", "munlock", "mlock2", "mlockall", "munlockall",
+	}
+	ociProfile.AllowSyscalls(syscallsToAllow...)
+
+	return ociProfile, nil
+}

--- a/secprofile/oci-profile.go
+++ b/secprofile/oci-profile.go
@@ -1,7 +1,7 @@
 package secprofile
 
 import (
-	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"reflect"
 )
 
@@ -96,7 +96,7 @@ func (p *OCIProfile) AddNamespaces(nsTypes ...specs.LinuxNamespaceType) {
 
 // AllowSyscallsWithArgs adds seccomp rules to allow syscalls with the given arguments if necessary
 func (p *OCIProfile) AllowSyscallsWithArgs(syscallsWithArgsToAllow map[string][]specs.LinuxSeccompArg) {
-	defaultActError := (p.OCI.Linux.Seccomp.DefaultAction == specs.ActErrno)
+	defaultActError := p.OCI.Linux.Seccomp.DefaultAction == specs.ActErrno
 
 	for syscallNameToAllow, syscallArgsToAllow := range syscallsWithArgsToAllow {
 
@@ -124,9 +124,20 @@ func (p *OCIProfile) AllowSyscallsWithArgs(syscallsWithArgsToAllow map[string][]
 	}
 }
 
+// AllowSyscalls adds seccomp rules to allow a list of syscalls without specific arguments
+func (p *OCIProfile) AllowSyscalls(syscallsToAllow ...string) {
+	syscallsWithNoArgsToAllow := make(map[string][]specs.LinuxSeccompArg)
+	for _, syscallsToAllow := range syscallsToAllow {
+		syscallsWithNoArgsToAllow[syscallsToAllow] = []specs.LinuxSeccompArg{}
+	}
+
+	p.AllowSyscallsWithArgs(syscallsWithNoArgsToAllow)
+}
+
 // BlockSyscallsWithArgs adds seccomp rules to block syscalls with the given arguments and remove them from allowed/debug rules if present
 func (p *OCIProfile) BlockSyscallsWithArgs(syscallsWithArgsToBlock map[string][]specs.LinuxSeccompArg) {
-	defaultActError := (p.OCI.Linux.Seccomp.DefaultAction == specs.ActErrno)
+	defaultActError := p.OCI.Linux.Seccomp.DefaultAction == specs.ActErrno
+
 	/* For each syscall to block we browse each syscall list of each Seccomp rule */
 	for syscallNameToBlock, syscallArgsToBlock := range syscallsWithArgsToBlock {
 		blocked := false


### PR DESCRIPTION
This PR is on top of https://github.com/docker/libentitlement/pull/30, this will get merged after the Pluggable Profiles update.

It adds the following entitlements:

- `security.confined` maximum level of security for the container
- `security.view` allows to read security configuration but no privileged action is allowed
- `security.admin`  allows to access and modify security configuration
- `security.memory-lock` allows to lock memory regions and prevents swapping

TODO:
Add AppArmor rules to configure access to sensitive filesystem locations