### PR TITLE
include golint in circle test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,5 +7,5 @@ jobs:
     working_directory: $GOPATH/src/github.com/docker/libentitlement
     steps:
       - checkout
-      - run: go get -u github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign
+      - run: go get -u github.com/golang/lint/golint github.com/fzipp/gocyclo github.com/client9/misspell/cmd/misspell github.com/gordonklaus/ineffassign
       - run: cd $GOPATH/src/github.com/docker/libentitlement && make test


### PR DESCRIPTION
Need to run `go get` from circle to make sure `golint` is included.

@n4ss: could you run `make test` locally on #31 before merge to ensure that `golint` passes?

Signed-off-by: Riyaz Faizullabhoy <riyaz.faizullabhoy@docker.com>