### PR TITLE
Add entitlement tests part2

### DIFF
--- a/defaults/host-ents.go
+++ b/defaults/host-ents.go
@@ -40,49 +40,8 @@ var (
 	hostProcessesAdminEntitlement = entitlement.NewVoidEntitlement(HostProcessesAdminEntFullID, hostProcessesAdminEntitlementEnforce)
 )
 
-var (
-	defaultMobyAllowedMounts = []specs.Mount{
-		{
-			Destination: "/proc",
-			Type:        "proc",
-			Source:      "proc",
-			Options:     []string{"nosuid", "noexec", "nodev"},
-		},
-		{
-			Destination: "/dev",
-			Type:        "tmpfs",
-			Source:      "tmpfs",
-			Options:     []string{"nosuid", "strictatime", "mode=755"},
-		},
-		{
-			Destination: "/dev/pts",
-			Type:        "devpts",
-			Source:      "devpts",
-			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
-		},
-		{
-			Destination: "/sys",
-			Type:        "sysfs",
-			Source:      "sysfs",
-			Options:     []string{"nosuid", "noexec", "nodev", "ro"},
-		},
-		{
-			Destination: "/sys/fs/cgroup",
-			Type:        "cgroup",
-			Source:      "cgroup",
-			Options:     []string{"ro", "nosuid", "noexec", "nodev"},
-		},
-		{
-			Destination: "/dev/mqueue",
-			Type:        "mqueue",
-			Source:      "mqueue",
-			Options:     []string{"nosuid", "noexec", "nodev"},
-		},
-	}
-)
-
 func isAllowedMount(mount specs.Mount) bool {
-	for _, allowedMount := range defaultMobyAllowedMounts {
+	for _, allowedMount := range osdefs.DefaultMobyAllowedMounts {
 		if reflect.DeepEqual(mount, allowedMount) {
 			return true
 		}
@@ -114,7 +73,7 @@ func hostDevicesNoneEntitlementEnforce(profile secprofile.Profile) (secprofile.P
 	ociProfile.OCI.Linux.ReadonlyPaths = append(ociProfile.OCI.Linux.ReadonlyPaths, "/sys")
 	ociProfile.OCI.Linux.MaskedPaths = append(ociProfile.OCI.Linux.MaskedPaths, "/proc/kcore")
 
-	ociProfile.OCI.Mounts = defaultMobyAllowedMounts
+	ociProfile.OCI.Mounts = osdefs.DefaultMobyAllowedMounts
 
 	return ociProfile, nil
 }
@@ -175,7 +134,7 @@ func hostDevicesAdminEntitlementEnforce(profile secprofile.Profile) (secprofile.
 	}
 
 	// FIXME: just remove read-only flags for default mounts and leave additional mounts as is
-	ociProfile.OCI.Mounts = removeReadOnlyFlagMounts(defaultMobyAllowedMounts)
+	ociProfile.OCI.Mounts = removeReadOnlyFlagMounts(osdefs.DefaultMobyAllowedMounts)
 
 	ociProfile.OCI.Linux.MaskedPaths = []string{}
 

--- a/defaults/host-ents.go
+++ b/defaults/host-ents.go
@@ -79,7 +79,7 @@ func hostDevicesNoneEntitlementEnforce(profile secprofile.Profile) (secprofile.P
 }
 
 /* Implements "host.devices.view" entitlement
- * - Sets all custom mounts to read-only
+ * - Sets all custom mount destinations to read-only
  */
 func hostDevicesViewEntitlementEnforce(profile secprofile.Profile) (secprofile.Profile, error) {
 	ociProfile, err := ociProfileConversionCheck(profile, HostDevicesViewEntFullID)

--- a/defaults/host-ents.go
+++ b/defaults/host-ents.go
@@ -134,7 +134,7 @@ func hostDevicesAdminEntitlementEnforce(profile secprofile.Profile) (secprofile.
 	}
 
 	// FIXME: just remove read-only flags for default mounts and leave additional mounts as is
-	ociProfile.OCI.Mounts = removeReadOnlyFlagMounts(osdefs.DefaultMobyAllowedMounts)
+	ociProfile.OCI.Mounts = removeReadOnlyFlagMounts(ociProfile.OCI.Mounts)
 
 	ociProfile.OCI.Linux.MaskedPaths = []string{}
 

--- a/defaults/host-ents_test.go
+++ b/defaults/host-ents_test.go
@@ -1,0 +1,43 @@
+package defaults
+
+import (
+	"github.com/docker/libentitlement/secprofile"
+	"github.com/docker/libentitlement/secprofile/osdefs"
+	"github.com/docker/libentitlement/testutils"
+	"github.com/docker/libentitlement/types"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestDevicesNoneEntitlementEnforce(t *testing.T) {
+	entitlementID := HostDevicesNoneEntFullID
+
+	ociProfile := secprofile.NewOCIProfile(testutils.TestSpec(), "test-profile")
+	require.Contains(t, DefaultEntitlements, entitlementID)
+
+	ent := DefaultEntitlements[entitlementID]
+
+	newProfile, err := ent.Enforce(ociProfile)
+	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
+
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
+	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
+
+	require.NotNil(t, newOCIProfile.OCI)
+	require.NotNil(t, newOCIProfile.OCI.Linux)
+	require.NotNil(t, newOCIProfile.OCI.Linux.Seccomp)
+	require.NotNil(t, newOCIProfile.OCI.Process.Capabilities)
+	require.NotNil(t, newOCIProfile.AppArmorSetup)
+
+	capsToRemove := []types.Capability{
+		osdefs.CapSysAdmin,
+	}
+	require.True(t, testutils.OCICapsMatchRefWithConstraints(*newOCIProfile.OCI.Process.Capabilities, nil, capsToRemove))
+
+	require.Contains(t, ociProfile.AppArmorSetup.Files.ReadOnly, "/sys/**")
+	require.Contains(t, ociProfile.AppArmorSetup.Files.Denied, "/proc/kcore/**")
+	require.Contains(t, ociProfile.OCI.Linux.ReadonlyPaths, "/sys")
+	require.Contains(t, ociProfile.OCI.Linux.MaskedPaths, "/proc/kcore")
+
+	require.Equal(t, ociProfile.OCI.Mounts, osdefs.DefaultMobyAllowedMounts)
+}

--- a/defaults/host-ents_test.go
+++ b/defaults/host-ents_test.go
@@ -41,3 +41,21 @@ func TestDevicesNoneEntitlementEnforce(t *testing.T) {
 
 	require.Equal(t, ociProfile.OCI.Mounts, osdefs.DefaultMobyAllowedMounts)
 }
+
+func TestDevicesViewEntitlementEnforce(t *testing.T) {
+	entitlementID := HostDevicesViewEntFullID
+
+	ociProfile := secprofile.NewOCIProfile(testutils.TestSpec(), "test-profile")
+	require.Contains(t, DefaultEntitlements, entitlementID)
+
+	ent := DefaultEntitlements[entitlementID]
+
+	newProfile, err := ent.Enforce(ociProfile)
+	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
+
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
+	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
+
+	nonDefaultMounts := testutils.GetNonDefaultMounts(ociProfile.OCI.Mounts)
+	require.True(t, testutils.PathListMatchRefMount(newOCIProfile.OCI.Linux.ReadonlyPaths, nonDefaultMounts))
+}

--- a/defaults/host-ents_test.go
+++ b/defaults/host-ents_test.go
@@ -140,3 +140,45 @@ func TestHostProcessesAdminEntitlementEnforce(t *testing.T) {
 	}
 	require.True(t, testutils.AreNamespacesDeactivated(newOCIProfile.OCI.Linux.Namespaces, nsToRemove))
 }
+
+func TestIsAllowedMount(t *testing.T) {
+	defaultMount := specs.Mount{
+		Destination: "/proc",
+		Type:        "proc",
+		Source:      "proc",
+		Options:     []string{"nosuid", "noexec", "nodev"},
+	}
+
+	require.True(t, isAllowedMount(defaultMount))
+
+	nonDefaultMount := specs.Mount{
+		Destination: "/foo/bar",
+		Type:        "foo",
+		Source:      "bar",
+		Options:     []string{},
+	}
+
+	require.False(t, isAllowedMount(nonDefaultMount))
+}
+
+func TestGetNonDefaultMount(t *testing.T) {
+	nonDefaultMount := []specs.Mount{
+		{
+			Destination: "/foo/bar",
+			Type:        "foo",
+			Source:      "bar",
+			Options:     []string{},
+		},
+	}
+	require.Equal(t, nonDefaultMount, testutils.GetNonDefaultMounts(nonDefaultMount))
+
+	defaultMount := []specs.Mount{
+		{
+			Destination: "/proc",
+			Type:        "proc",
+			Source:      "proc",
+			Options:     []string{"nosuid", "noexec", "nodev"},
+		},
+	}
+	require.Empty(t, testutils.GetNonDefaultMounts(defaultMount))
+}

--- a/defaults/host-ents_test.go
+++ b/defaults/host-ents_test.go
@@ -1,15 +1,17 @@
 package defaults
 
 import (
+	"testing"
+
 	"github.com/docker/libentitlement/secprofile"
 	"github.com/docker/libentitlement/secprofile/osdefs"
 	"github.com/docker/libentitlement/testutils"
 	"github.com/docker/libentitlement/types"
+	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
-func TestDevicesNoneEntitlementEnforce(t *testing.T) {
+func TestHostDevicesNoneEntitlementEnforce(t *testing.T) {
 	entitlementID := HostDevicesNoneEntFullID
 
 	ociProfile := secprofile.NewOCIProfile(testutils.TestSpec(), "test-profile")
@@ -42,7 +44,7 @@ func TestDevicesNoneEntitlementEnforce(t *testing.T) {
 	require.Equal(t, ociProfile.OCI.Mounts, osdefs.DefaultMobyAllowedMounts)
 }
 
-func TestDevicesViewEntitlementEnforce(t *testing.T) {
+func TestHostDevicesViewEntitlementEnforce(t *testing.T) {
 	entitlementID := HostDevicesViewEntFullID
 
 	ociProfile := secprofile.NewOCIProfile(testutils.TestSpec(), "test-profile")
@@ -56,6 +58,85 @@ func TestDevicesViewEntitlementEnforce(t *testing.T) {
 	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
 	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
 
+	require.NotNil(t, newOCIProfile.OCI)
+	require.NotNil(t, newOCIProfile.OCI.Linux)
+
 	nonDefaultMounts := testutils.GetNonDefaultMounts(ociProfile.OCI.Mounts)
 	require.True(t, testutils.PathListMatchRefMount(newOCIProfile.OCI.Linux.ReadonlyPaths, nonDefaultMounts))
+}
+
+func TestHostDevicesAdminEntitlementEnforce(t *testing.T) {
+	entitlementID := HostDevicesAdminEntFullID
+
+	ociProfile := secprofile.NewOCIProfile(testutils.TestSpec(), "test-profile")
+	require.Contains(t, DefaultEntitlements, entitlementID)
+
+	ent := DefaultEntitlements[entitlementID]
+
+	newProfile, err := ent.Enforce(ociProfile)
+	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
+
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
+	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
+
+	require.NotNil(t, newOCIProfile.OCI)
+	require.NotNil(t, newOCIProfile.OCI.Linux)
+	require.NotNil(t, newOCIProfile.OCI.Process.Capabilities)
+
+	capsToAdd := []types.Capability{
+		osdefs.CapSysAdmin,
+	}
+	require.True(t, testutils.OCICapsMatchRefWithConstraints(*newOCIProfile.OCI.Process.Capabilities, capsToAdd, nil))
+
+	for _, mount := range ociProfile.OCI.Mounts {
+		require.NotContains(t, mount.Options, "ro")
+	}
+
+	require.Empty(t, ociProfile.OCI.Linux.MaskedPaths)
+}
+
+func TestHostProcessesNoneEntitlementEnforce(t *testing.T) {
+	entitlementID := HostProcessesNoneEntFullID
+
+	ociProfile := secprofile.NewOCIProfile(testutils.TestSpec(), "test-profile")
+	require.Contains(t, DefaultEntitlements, entitlementID)
+
+	ent := DefaultEntitlements[entitlementID]
+
+	newProfile, err := ent.Enforce(ociProfile)
+	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
+
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
+	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
+
+	require.NotNil(t, newOCIProfile.OCI)
+	require.NotNil(t, newOCIProfile.OCI.Linux)
+
+	nsToAdd := []specs.LinuxNamespaceType{
+		specs.PIDNamespace,
+	}
+	require.True(t, testutils.AreNamespacesActivated(newOCIProfile.OCI.Linux.Namespaces, nsToAdd))
+}
+
+func TestHostProcessesAdminEntitlementEnforce(t *testing.T) {
+	entitlementID := HostProcessesAdminEntFullID
+
+	ociProfile := secprofile.NewOCIProfile(testutils.TestSpec(), "test-profile")
+	require.Contains(t, DefaultEntitlements, entitlementID)
+
+	ent := DefaultEntitlements[entitlementID]
+
+	newProfile, err := ent.Enforce(ociProfile)
+	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
+
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
+	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
+
+	require.NotNil(t, newOCIProfile.OCI)
+	require.NotNil(t, newOCIProfile.OCI.Linux)
+
+	nsToRemove := []specs.LinuxNamespaceType{
+		specs.PIDNamespace,
+	}
+	require.True(t, testutils.AreNamespacesDeactivated(newOCIProfile.OCI.Linux.Namespaces, nsToRemove))
 }

--- a/defaults/network-ents_test.go
+++ b/defaults/network-ents_test.go
@@ -23,7 +23,7 @@ func TestNetworkNoneEntitlementEnforce(t *testing.T) {
 	newProfile, err := ent.Enforce(ociProfile)
 	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
 
-	newOCIProfile, err := ociProfileConversionCheck(newProfile, NetworkNoneEntFullID)
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
 	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
 
 	require.NotNil(t, newOCIProfile.OCI)
@@ -78,7 +78,7 @@ func TestNetworkUserEntitlementEnforce(t *testing.T) {
 	newProfile, err := ent.Enforce(ociProfile)
 	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
 
-	newOCIProfile, err := ociProfileConversionCheck(newProfile, NetworkUserEntFullID)
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
 	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
 
 	require.NotNil(t, newOCIProfile.OCI)
@@ -104,7 +104,7 @@ func TestNetworkProxyEntitlementEnforce(t *testing.T) {
 	newProfile, err := ent.Enforce(ociProfile)
 	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
 
-	newOCIProfile, err := ociProfileConversionCheck(newProfile, NetworkProxyEntFullID)
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
 	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
 
 	require.NotNil(t, newOCIProfile.OCI)
@@ -145,7 +145,7 @@ func TestNetworkAdminEntitlementEnforce(t *testing.T) {
 	newProfile, err := ent.Enforce(ociProfile)
 	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
 
-	newOCIProfile, err := ociProfileConversionCheck(newProfile, NetworkAdminEntFullID)
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
 	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
 
 	require.NotNil(t, newOCIProfile.OCI)

--- a/defaults/security-ents.go
+++ b/defaults/security-ents.go
@@ -102,6 +102,7 @@ func securityViewEntitlementEnforce(profile secprofile.Profile) (secprofile.Prof
 		osdefs.SysPtrace,
 		osdefs.SysPersonality,
 		osdefs.SysMadvise,
+		// FIXME: try with: osdefs.SysPrctl,
 	}
 	ociProfile.BlockSyscalls(syscallsToBlock...)
 

--- a/defaults/security-ents_test.go
+++ b/defaults/security-ents_test.go
@@ -1,0 +1,170 @@
+package defaults
+
+import (
+	"github.com/docker/libentitlement/secprofile"
+	"github.com/docker/libentitlement/secprofile/osdefs"
+	"github.com/docker/libentitlement/testutils"
+	"github.com/docker/libentitlement/types"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestSecurityConfinedEntitlementEnforce(t *testing.T) {
+	entitlementID := SecurityConfinedEntFullID
+
+	ociProfile := secprofile.NewOCIProfile(testutils.TestSpec(), "test-profile")
+	require.Contains(t, DefaultEntitlements, entitlementID)
+
+	ent := DefaultEntitlements[entitlementID]
+
+	newProfile, err := ent.Enforce(ociProfile)
+	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
+
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
+	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
+
+	require.NotNil(t, newOCIProfile.OCI)
+	require.NotNil(t, newOCIProfile.OCI.Linux)
+	require.NotNil(t, newOCIProfile.OCI.Linux.Seccomp)
+	require.NotNil(t, newOCIProfile.OCI.Process.Capabilities)
+
+	capsToRemove := []types.Capability{
+		osdefs.CapMacAdmin, osdefs.CapMacOverride, osdefs.CapDacOverride, osdefs.CapDacReadSearch, osdefs.CapSetpcap, osdefs.CapSetfcap, osdefs.CapSetuid, osdefs.CapSetgid,
+		osdefs.CapSysPtrace, osdefs.CapFsetid, osdefs.CapSysModule, osdefs.CapSyslog, osdefs.CapSysRawio, osdefs.CapSysAdmin, osdefs.CapLinuxImmutable,
+	}
+	require.True(t, testutils.OCICapsMatchRefWithConstraints(*newOCIProfile.OCI.Process.Capabilities, nil, capsToRemove))
+
+	syscallsToBlock := []types.Syscall{
+		osdefs.SysPtrace, osdefs.SysArchPrctl, osdefs.SysPersonality, osdefs.SysMadvise,
+	}
+	require.True(t, testutils.AreSyscallsBlockedBySeccomp(*newOCIProfile.OCI.Linux.Seccomp, syscallsToBlock))
+
+	syscallsWithArgsToAllow := map[types.Syscall][]specs.LinuxSeccompArg{
+		osdefs.SysPrctl: {
+			{
+				Index: 0,
+				Value: osdefs.PrCapbsetDrop,
+				Op:    specs.OpNotEqual,
+			},
+			{
+				Index: 0,
+				Value: osdefs.PrCapbsetRead,
+				Op:    specs.OpNotEqual,
+			},
+		},
+	}
+	require.True(t, testutils.AreSeccompSyscallsWithArgsAllowed(*newOCIProfile.OCI.Linux.Seccomp, syscallsWithArgsToAllow))
+}
+
+func TestSecurityViewEntitlementEnforce(t *testing.T) {
+	entitlementID := SecurityViewEntFullID
+
+	ociProfile := secprofile.NewOCIProfile(testutils.TestSpec(), "test-profile")
+	require.Contains(t, DefaultEntitlements, entitlementID)
+
+	ent := DefaultEntitlements[entitlementID]
+
+	newProfile, err := ent.Enforce(ociProfile)
+	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
+
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
+	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
+
+	require.NotNil(t, newOCIProfile.OCI)
+	require.NotNil(t, newOCIProfile.OCI.Linux)
+	require.NotNil(t, newOCIProfile.OCI.Linux.Seccomp)
+	require.NotNil(t, newOCIProfile.OCI.Process.Capabilities)
+
+	capsToRemove := []types.Capability{
+		osdefs.CapSysAdmin, osdefs.CapSysPtrace,
+		osdefs.CapSetuid, osdefs.CapSetgid, osdefs.CapSetpcap, osdefs.CapSetfcap,
+		osdefs.CapMacAdmin, osdefs.CapMacOverride, osdefs.CapAuditRead,
+		osdefs.CapDacOverride, osdefs.CapFsetid, osdefs.CapSysModule, osdefs.CapSyslog, osdefs.CapSysRawio, osdefs.CapLinuxImmutable,
+	}
+	capsToAdd := []types.Capability{osdefs.CapDacReadSearch}
+	require.True(t, testutils.OCICapsMatchRefWithConstraints(*newOCIProfile.OCI.Process.Capabilities, capsToAdd, capsToRemove))
+
+	syscallsToBlock := []types.Syscall{
+		osdefs.SysPtrace,
+		osdefs.SysPersonality,
+		osdefs.SysMadvise,
+	}
+	require.True(t, testutils.AreSyscallsBlockedBySeccomp(*newOCIProfile.OCI.Linux.Seccomp, syscallsToBlock))
+
+	syscallsWithArgsToAllow := map[types.Syscall][]specs.LinuxSeccompArg{
+		osdefs.SysPrctl: {
+			{
+				Index: 0,
+				Value: osdefs.PrCapbsetDrop,
+				Op:    specs.OpNotEqual,
+			},
+		},
+	}
+	require.True(t, testutils.AreSeccompSyscallsWithArgsAllowed(*newOCIProfile.OCI.Linux.Seccomp, syscallsWithArgsToAllow))
+}
+
+func TestSecurityAdminEntitlementEnforce(t *testing.T) {
+	entitlementID := SecurityAdminEntFullID
+
+	ociProfile := secprofile.NewOCIProfile(testutils.TestSpec(), "test-profile")
+	require.Contains(t, DefaultEntitlements, entitlementID)
+
+	ent := DefaultEntitlements[entitlementID]
+
+	newProfile, err := ent.Enforce(ociProfile)
+	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
+
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
+	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
+
+	require.NotNil(t, newOCIProfile.OCI)
+	require.NotNil(t, newOCIProfile.OCI.Linux)
+	require.NotNil(t, newOCIProfile.OCI.Linux.Seccomp)
+	require.NotNil(t, newOCIProfile.OCI.Process.Capabilities)
+
+	capsToAdd := []types.Capability{
+		osdefs.CapMacAdmin, osdefs.CapMacOverride, osdefs.CapDacOverride, osdefs.CapDacReadSearch, osdefs.CapSetpcap, osdefs.CapSetfcap, osdefs.CapSetuid, osdefs.CapSetgid,
+		osdefs.CapSysPtrace, osdefs.CapFsetid, osdefs.CapSysModule, osdefs.CapSyslog, osdefs.CapSysRawio, osdefs.CapSysAdmin, osdefs.CapLinuxImmutable, osdefs.CapSysBoot,
+		osdefs.CapSysNice, osdefs.CapSysPacct, osdefs.CapSysTtyConfig, osdefs.CapSysTime, osdefs.CapWakeAlarm, osdefs.CapAuditRead, osdefs.CapAuditWrite, osdefs.CapAuditControl,
+	}
+	require.True(t, testutils.OCICapsMatchRefWithConstraints(*newOCIProfile.OCI.Process.Capabilities, capsToAdd, nil))
+
+	syscallsToAllow := []types.Syscall{
+		osdefs.SysPtrace, osdefs.SysArchPrctl, osdefs.SysPersonality, osdefs.SysSetuid, osdefs.SysSetgid, osdefs.SysPrctl, osdefs.SysMadvise, osdefs.SysMount, osdefs.SysInitModule,
+		osdefs.SysFinitModule, osdefs.SysSetns, osdefs.SysClone, osdefs.SysUnshare,
+	}
+	require.True(t, testutils.AreSyscallsAllowedBySeccomp(*newOCIProfile.OCI.Linux.Seccomp, syscallsToAllow))
+
+	require.Empty(t, ociProfile.OCI.Linux.ReadonlyPaths)
+}
+
+func TestSecurityMemoryLockEntitlementEnforce(t *testing.T) {
+	entitlementID := SecurityMemoryLockFullID
+
+	ociProfile := secprofile.NewOCIProfile(testutils.TestSpec(), "test-profile")
+	require.Contains(t, DefaultEntitlements, entitlementID)
+
+	ent := DefaultEntitlements[entitlementID]
+
+	newProfile, err := ent.Enforce(ociProfile)
+	require.NoError(t, err, "Failed enforce while testing entitlement %s", entitlementID)
+
+	newOCIProfile, err := ociProfileConversionCheck(newProfile, entitlementID)
+	require.NoError(t, err, "Failed converting to OCI profile while testing entitlement %s", entitlementID)
+
+	require.NotNil(t, newOCIProfile.OCI)
+	require.NotNil(t, newOCIProfile.OCI.Linux)
+	require.NotNil(t, newOCIProfile.OCI.Linux.Seccomp)
+	require.NotNil(t, newOCIProfile.OCI.Process.Capabilities)
+
+	capsToAdd := []types.Capability{
+		osdefs.CapIpcLock,
+	}
+	require.True(t, testutils.OCICapsMatchRefWithConstraints(*newOCIProfile.OCI.Process.Capabilities, capsToAdd, nil))
+
+	syscallsToAllow := []types.Syscall{
+		osdefs.SysMlock, osdefs.SysMunlock, osdefs.SysMlock2, osdefs.SysMlockall, osdefs.SysMunlockall,
+	}
+	require.True(t, testutils.AreSyscallsAllowedBySeccomp(*newOCIProfile.OCI.Linux.Seccomp, syscallsToAllow))
+}

--- a/defaults/security-ents_test.go
+++ b/defaults/security-ents_test.go
@@ -1,13 +1,14 @@
 package defaults
 
 import (
+	"testing"
+
 	"github.com/docker/libentitlement/secprofile"
 	"github.com/docker/libentitlement/secprofile/osdefs"
 	"github.com/docker/libentitlement/testutils"
 	"github.com/docker/libentitlement/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestSecurityConfinedEntitlementEnforce(t *testing.T) {

--- a/secprofile/oci-profile.go
+++ b/secprofile/oci-profile.go
@@ -1,11 +1,12 @@
 package secprofile
 
 import (
+	"reflect"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/libentitlement/apparmor"
 	"github.com/docker/libentitlement/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"reflect"
 )
 
 // OCIProfileType is an identifier for an OCI profile
@@ -118,7 +119,7 @@ func allowSyscallWithArgs(seccompProfile *specs.LinuxSeccomp, syscallName types.
 				if syscallName == syscallNameToAllowStr &&
 					((len(syscallArgs) == 0 && len(syscallRule.Args) == 0) ||
 						reflect.DeepEqual(syscallRule.Args, syscallArgs)) {
-					logrus.Errorf("Syscall already added: %s", syscallNameToAllowStr)
+					logrus.Debugf("Syscall already added to Seccomp profile: %s", syscallNameToAllowStr)
 					return seccompProfile
 				}
 			}

--- a/secprofile/oci-profile_test.go
+++ b/secprofile/oci-profile_test.go
@@ -1,0 +1,29 @@
+package secprofile
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/docker/libentitlement/secprofile/osdefs"
+	"github.com/docker/libentitlement/testutils"
+	"github.com/docker/libentitlement/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlreadyPresentSyscall(t *testing.T) {
+	testSyscall := osdefs.SysExit
+	ociProfile := NewOCIProfile(testutils.TestSpec(), "test-profile")
+
+	require.NotNil(t, ociProfile.OCI)
+	require.NotNil(t, ociProfile.OCI.Linux)
+	require.NotNil(t, ociProfile.OCI.Linux.Seccomp)
+
+	syscalls := []types.Syscall{testSyscall}
+	ociProfile.AllowSyscalls(syscalls...)
+
+	seccompProfileWithTestSys := *ociProfile.OCI.Linux.Seccomp
+
+	ociProfile.AllowSyscalls(syscalls...)
+	didAdd := reflect.DeepEqual(seccompProfileWithTestSys, *ociProfile.OCI.Linux.Seccomp)
+	require.True(t, didAdd, "Syscall was not already added to the seccomp profile")
+}

--- a/secprofile/osdefs/mounts.go
+++ b/secprofile/osdefs/mounts.go
@@ -1,0 +1,45 @@
+package osdefs
+
+import "github.com/opencontainers/runtime-spec/specs-go"
+
+var (
+	// DefaultMobyAllowedMounts holds the default Moby mounts
+	DefaultMobyAllowedMounts = []specs.Mount{
+		{
+			Destination: "/proc",
+			Type:        "proc",
+			Source:      "proc",
+			Options:     []string{"nosuid", "noexec", "nodev"},
+		},
+		{
+			Destination: "/dev",
+			Type:        "tmpfs",
+			Source:      "tmpfs",
+			Options:     []string{"nosuid", "strictatime", "mode=755"},
+		},
+		{
+			Destination: "/dev/pts",
+			Type:        "devpts",
+			Source:      "devpts",
+			Options:     []string{"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620", "gid=5"},
+		},
+		{
+			Destination: "/sys",
+			Type:        "sysfs",
+			Source:      "sysfs",
+			Options:     []string{"nosuid", "noexec", "nodev", "ro"},
+		},
+		{
+			Destination: "/sys/fs/cgroup",
+			Type:        "cgroup",
+			Source:      "cgroup",
+			Options:     []string{"ro", "nosuid", "noexec", "nodev"},
+		},
+		{
+			Destination: "/dev/mqueue",
+			Type:        "mqueue",
+			Source:      "mqueue",
+			Options:     []string{"nosuid", "noexec", "nodev"},
+		},
+	}
+)

--- a/testutils/moby-defaults.go
+++ b/testutils/moby-defaults.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"reflect"
 	"runtime"
 
 	"github.com/docker/libentitlement/secprofile/osdefs"
@@ -75,4 +76,28 @@ func getDefaultCapSet() map[types.Capability]bool {
 	}
 
 	return capSet
+}
+
+// GetNonDefaultMounts returns a mount set from the provided mount list without default Moby mounts that it may contain
+func GetNonDefaultMounts(mountList []specs.Mount) []specs.Mount {
+	defaultMountList := osdefs.DefaultMobyAllowedMounts
+
+	nonDefaultMounts := []specs.Mount{}
+
+	for _, mount := range mountList {
+		found := false
+
+		for _, defaultMount := range defaultMountList {
+			if reflect.DeepEqual(defaultMount, mount) {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			nonDefaultMounts = append(nonDefaultMounts, mount)
+		}
+	}
+
+	return nonDefaultMounts
 }

--- a/testutils/ocispec.go
+++ b/testutils/ocispec.go
@@ -305,3 +305,27 @@ func AreNamespacesDeactivated(nsList []specs.LinuxNamespace, namespaces []specs.
 
 	return true
 }
+
+// PathListMatchRefMount checks that the path list holds exactly the mount destinations of the provided mount list
+func PathListMatchRefMount(mountPathList []string, refMounts []specs.Mount) bool {
+	if len(mountPathList) != len(refMounts) {
+		return false
+	}
+
+	for _, mountPath := range mountPathList {
+		found := false
+
+		for _, mount := range refMounts {
+			if mount.Destination == mountPath {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			return false
+		}
+	}
+
+	return true
+}

--- a/testutils/ocispec.go
+++ b/testutils/ocispec.go
@@ -153,6 +153,33 @@ func AreSyscallsBlockedBySeccomp(seccompProfile specs.LinuxSeccomp, syscallNames
 	return true
 }
 
+// isSyscallWithArgsAllowedBySeccomp checks that the provided syscall and args are whitelisted by the seccomp profile
+func isSyscallWithArgsAllowedBySeccomp(seccompProfile specs.LinuxSeccomp, syscallName types.Syscall, syscallArgs []specs.LinuxSeccompArg) bool {
+	return !isSyscallWithArgsBlockedBySeccomp(seccompProfile, syscallName, syscallArgs)
+}
+
+// AreSeccompSyscallsWithArgsAllowed checks that the provided list of syscalls and args are whitelisted by the seccomp profile
+func AreSeccompSyscallsWithArgsAllowed(seccompProfile specs.LinuxSeccomp, syscallsWithArgs map[types.Syscall][]specs.LinuxSeccompArg) bool {
+	for syscallName, syscallArgs := range syscallsWithArgs {
+		if !isSyscallWithArgsAllowedBySeccomp(seccompProfile, syscallName, syscallArgs) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// AreSyscallsAllowedBySeccomp checks that the provided syscalls are whitelisted by the seccomp profile
+func AreSyscallsAllowedBySeccomp(seccompProfile specs.LinuxSeccomp, syscallNames []types.Syscall) bool {
+	for _, syscallName := range syscallNames {
+		if !isSyscallWithArgsAllowedBySeccomp(seccompProfile, syscallName, []specs.LinuxSeccompArg{}) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // isCapBlocked checks that the provided capability is not allowed
 func isCapBlocked(linuxCaps specs.LinuxCapabilities, capability types.Capability) bool {
 	return !(capListContains(linuxCaps.Bounding, capability) || capListContains(linuxCaps.Permitted, capability) ||

--- a/testutils/ocispec_test.go
+++ b/testutils/ocispec_test.go
@@ -1,0 +1,27 @@
+package testutils
+
+import (
+	"sort"
+	"testing"
+
+	"github.com/docker/libentitlement/secprofile/osdefs"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPathListMatchRefMount(t *testing.T) {
+	refMounts := osdefs.DefaultMobyAllowedMounts
+
+	mountPathsReverse := make([]string, len(refMounts))
+	for index, mount := range refMounts {
+		mountPathsReverse[index] = mount.Destination
+	}
+
+	// We test for a reverse version of the list, PathListMatchRefMount should still work
+	sort.Sort(sort.Reverse(sort.StringSlice(mountPathsReverse)))
+
+	require.True(t, PathListMatchRefMount(mountPathsReverse, refMounts), "Mount destination list and ref mount list should match.")
+
+	// Cut the last element and test again, should fail
+	mountPathsReverseWithoutLast := mountPathsReverse[:len(mountPathsReverse)-1]
+	require.False(t, PathListMatchRefMount(mountPathsReverseWithoutLast, refMounts), "Mount destination list and ref mount list should not match.")
+}


### PR DESCRIPTION
Follow-up PR with `security.*` and `host.*` entitlements tests.

I tried to backport all comments from the [first PR](https://github.com/docker/libentitlement/pull/45).

New:
- I moved the default Moby mounts (which are the same as libcontainers') to a shared package between test utils, entitlements and entitlements tests.
- I added some helpers for OCI Mount objects checks
- Implemented `security.*` and `host.*` entitlements tests

This should close https://github.com/docker/libentitlement/issues/37